### PR TITLE
Finish translation

### DIFF
--- a/ScintillaNet_FindReplaceDialog/FindAllResults/FindAllResultsPanel.cs
+++ b/ScintillaNet_FindReplaceDialog/FindAllResults/FindAllResultsPanel.cs
@@ -85,7 +85,7 @@
 
                 if (startLine == endLine)
                 {
-                    string resultsLinePrefix = string.Format("Line {0}: ", startLine + 1);
+                    string resultsLinePrefix = string.Format(Properties.Resources.FindAllResults_ResultsLinePrefix, startLine + 1);
 
                     FindResultsScintilla.AppendText(string.Format("{0}{1}",
                         resultsLinePrefix, Scintilla.Lines[startLine].Text));

--- a/ScintillaNet_FindReplaceDialog/FindReplace/FindReplaceDialog.Designer.cs
+++ b/ScintillaNet_FindReplaceDialog/FindReplace/FindReplaceDialog.Designer.cs
@@ -181,6 +181,12 @@ namespace ScintillaNET_FindReplaceDialog
       this.toolStripMenuItem51 = new System.Windows.Forms.ToolStripMenuItem();
       this.toolStripMenuItem50 = new System.Windows.Forms.ToolStripMenuItem();
       this.nameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.toolStripSeparator9 = new System.Windows.Forms.ToolStripSeparator();
+      this.clearHistoryToolStripMenuItemFindF = new System.Windows.Forms.ToolStripMenuItem();
+      this.toolStripSeparator10 = new System.Windows.Forms.ToolStripSeparator();
+      this.clearHistoryToolStripMenuItemFindR = new System.Windows.Forms.ToolStripMenuItem();
+      this.toolStripSeparator11 = new System.Windows.Forms.ToolStripSeparator();
+      this.clearHistoryToolStripMenuItemReplace = new System.Windows.Forms.ToolStripMenuItem();
       this.tabAll.SuspendLayout();
       this.tpgFind.SuspendLayout();
       this.grpFindAll.SuspendLayout();
@@ -193,8 +199,11 @@ namespace ScintillaNET_FindReplaceDialog
       this.pnlRegexpOptionsR.SuspendLayout();
       this.statusStrip.SuspendLayout();
       this.mnuExtendedCharFindF.SuspendLayout();
+      this.mnuRecentFindF.SuspendLayout();
       this.mnuExtendedCharFindR.SuspendLayout();
       this.mnuExtendedCharReplace.SuspendLayout();
+      this.mnuRecentFindR.SuspendLayout();
+      this.mnuRecentReplace.SuspendLayout();
       this.mnuRegExCharFindF.SuspendLayout();
       this.mnuRegExCharFindR.SuspendLayout();
       this.mnuRegExCharReplace.SuspendLayout();
@@ -202,17 +211,15 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       // tabAll
       // 
-      resources.ApplyResources(this.tabAll, "tabAll");
       this.tabAll.Controls.Add(this.tpgFind);
       this.tabAll.Controls.Add(this.tpgReplace);
+      resources.ApplyResources(this.tabAll, "tabAll");
       this.tabAll.Name = "tabAll";
       this.tabAll.SelectedIndex = 0;
-      this.toolTip1.SetToolTip(this.tabAll, resources.GetString("tabAll.ToolTip"));
       this.tabAll.SelectedIndexChanged += new System.EventHandler(this.tabAll_SelectedIndexChanged);
       // 
       // tpgFind
       // 
-      resources.ApplyResources(this.tpgFind, "tpgFind");
       this.tpgFind.Controls.Add(this.cmdRecentFindF);
       this.tpgFind.Controls.Add(this.txtFindF);
       this.tpgFind.Controls.Add(this.cmdExtCharAndRegExFindF);
@@ -227,8 +234,8 @@ namespace ScintillaNET_FindReplaceDialog
       this.tpgFind.Controls.Add(this.rdoRegexF);
       this.tpgFind.Controls.Add(this.rdoStandardF);
       this.tpgFind.Controls.Add(this.lblFindF);
+      resources.ApplyResources(this.tpgFind, "tpgFind");
       this.tpgFind.Name = "tpgFind";
-      this.toolTip1.SetToolTip(this.tpgFind, resources.GetString("tpgFind.ToolTip"));
       this.tpgFind.UseVisualStyleBackColor = true;
       // 
       // cmdRecentFindF
@@ -244,7 +251,6 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.txtFindF, "txtFindF");
       this.txtFindF.Name = "txtFindF";
-      this.toolTip1.SetToolTip(this.txtFindF, resources.GetString("txtFindF.ToolTip"));
       // 
       // cmdExtCharAndRegExFindF
       // 
@@ -258,26 +264,23 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.rdoExtendedF, "rdoExtendedF");
       this.rdoExtendedF.Name = "rdoExtendedF";
-      this.toolTip1.SetToolTip(this.rdoExtendedF, resources.GetString("rdoExtendedF.ToolTip"));
       this.rdoExtendedF.UseVisualStyleBackColor = true;
       this.rdoExtendedF.CheckedChanged += new System.EventHandler(this.rdoStandardF_CheckedChanged);
       // 
       // grpFindAll
       // 
-      resources.ApplyResources(this.grpFindAll, "grpFindAll");
       this.grpFindAll.Controls.Add(this.btnClear);
       this.grpFindAll.Controls.Add(this.btnFindAll);
       this.grpFindAll.Controls.Add(this.chkHighlightMatches);
       this.grpFindAll.Controls.Add(this.chkMarkLine);
+      resources.ApplyResources(this.grpFindAll, "grpFindAll");
       this.grpFindAll.Name = "grpFindAll";
       this.grpFindAll.TabStop = false;
-      this.toolTip1.SetToolTip(this.grpFindAll, resources.GetString("grpFindAll.ToolTip"));
       // 
       // btnClear
       // 
       resources.ApplyResources(this.btnClear, "btnClear");
       this.btnClear.Name = "btnClear";
-      this.toolTip1.SetToolTip(this.btnClear, resources.GetString("btnClear.ToolTip"));
       this.btnClear.UseVisualStyleBackColor = true;
       this.btnClear.Click += new System.EventHandler(this.btnClear_Click);
       // 
@@ -285,7 +288,6 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.btnFindAll, "btnFindAll");
       this.btnFindAll.Name = "btnFindAll";
-      this.toolTip1.SetToolTip(this.btnFindAll, resources.GetString("btnFindAll.ToolTip"));
       this.btnFindAll.UseVisualStyleBackColor = true;
       this.btnFindAll.Click += new System.EventHandler(this.btnFindAll_Click);
       // 
@@ -293,21 +295,18 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.chkHighlightMatches, "chkHighlightMatches");
       this.chkHighlightMatches.Name = "chkHighlightMatches";
-      this.toolTip1.SetToolTip(this.chkHighlightMatches, resources.GetString("chkHighlightMatches.ToolTip"));
       this.chkHighlightMatches.UseVisualStyleBackColor = true;
       // 
       // chkMarkLine
       // 
       resources.ApplyResources(this.chkMarkLine, "chkMarkLine");
       this.chkMarkLine.Name = "chkMarkLine";
-      this.toolTip1.SetToolTip(this.chkMarkLine, resources.GetString("chkMarkLine.ToolTip"));
       this.chkMarkLine.UseVisualStyleBackColor = true;
       // 
       // chkSearchSelectionF
       // 
       resources.ApplyResources(this.chkSearchSelectionF, "chkSearchSelectionF");
       this.chkSearchSelectionF.Name = "chkSearchSelectionF";
-      this.toolTip1.SetToolTip(this.chkSearchSelectionF, resources.GetString("chkSearchSelectionF.ToolTip"));
       this.chkSearchSelectionF.UseVisualStyleBackColor = true;
       // 
       // chkWrapF
@@ -316,14 +315,12 @@ namespace ScintillaNET_FindReplaceDialog
       this.chkWrapF.Checked = true;
       this.chkWrapF.CheckState = System.Windows.Forms.CheckState.Checked;
       this.chkWrapF.Name = "chkWrapF";
-      this.toolTip1.SetToolTip(this.chkWrapF, resources.GetString("chkWrapF.ToolTip"));
       this.chkWrapF.UseVisualStyleBackColor = true;
       // 
       // btnFindPreviousF
       // 
       resources.ApplyResources(this.btnFindPreviousF, "btnFindPreviousF");
       this.btnFindPreviousF.Name = "btnFindPreviousF";
-      this.toolTip1.SetToolTip(this.btnFindPreviousF, resources.GetString("btnFindPreviousF.ToolTip"));
       this.btnFindPreviousF.UseVisualStyleBackColor = true;
       this.btnFindPreviousF.Click += new System.EventHandler(this.btnFindPrevious_Click);
       // 
@@ -331,7 +328,6 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.btnFindNextF, "btnFindNextF");
       this.btnFindNextF.Name = "btnFindNextF";
-      this.toolTip1.SetToolTip(this.btnFindNextF, resources.GetString("btnFindNextF.ToolTip"));
       this.btnFindNextF.UseVisualStyleBackColor = true;
       this.btnFindNextF.Click += new System.EventHandler(this.btnFindNext_Click);
       // 
@@ -342,41 +338,35 @@ namespace ScintillaNET_FindReplaceDialog
       this.grpOptionsF.Controls.Add(this.pnlRegexpOptionsF);
       this.grpOptionsF.Name = "grpOptionsF";
       this.grpOptionsF.TabStop = false;
-      this.toolTip1.SetToolTip(this.grpOptionsF, resources.GetString("grpOptionsF.ToolTip"));
       // 
       // pnlStandardOptionsF
       // 
-      resources.ApplyResources(this.pnlStandardOptionsF, "pnlStandardOptionsF");
       this.pnlStandardOptionsF.Controls.Add(this.chkWordStartF);
       this.pnlStandardOptionsF.Controls.Add(this.chkWholeWordF);
       this.pnlStandardOptionsF.Controls.Add(this.chkMatchCaseF);
+      resources.ApplyResources(this.pnlStandardOptionsF, "pnlStandardOptionsF");
       this.pnlStandardOptionsF.Name = "pnlStandardOptionsF";
-      this.toolTip1.SetToolTip(this.pnlStandardOptionsF, resources.GetString("pnlStandardOptionsF.ToolTip"));
       // 
       // chkWordStartF
       // 
       resources.ApplyResources(this.chkWordStartF, "chkWordStartF");
       this.chkWordStartF.Name = "chkWordStartF";
-      this.toolTip1.SetToolTip(this.chkWordStartF, resources.GetString("chkWordStartF.ToolTip"));
       this.chkWordStartF.UseVisualStyleBackColor = true;
       // 
       // chkWholeWordF
       // 
       resources.ApplyResources(this.chkWholeWordF, "chkWholeWordF");
       this.chkWholeWordF.Name = "chkWholeWordF";
-      this.toolTip1.SetToolTip(this.chkWholeWordF, resources.GetString("chkWholeWordF.ToolTip"));
       this.chkWholeWordF.UseVisualStyleBackColor = true;
       // 
       // chkMatchCaseF
       // 
       resources.ApplyResources(this.chkMatchCaseF, "chkMatchCaseF");
       this.chkMatchCaseF.Name = "chkMatchCaseF";
-      this.toolTip1.SetToolTip(this.chkMatchCaseF, resources.GetString("chkMatchCaseF.ToolTip"));
       this.chkMatchCaseF.UseVisualStyleBackColor = true;
       // 
       // pnlRegexpOptionsF
       // 
-      resources.ApplyResources(this.pnlRegexpOptionsF, "pnlRegexpOptionsF");
       this.pnlRegexpOptionsF.Controls.Add(this.chkSinglelineF);
       this.pnlRegexpOptionsF.Controls.Add(this.chkRightToLeftF);
       this.pnlRegexpOptionsF.Controls.Add(this.chkMultilineF);
@@ -386,56 +376,49 @@ namespace ScintillaNET_FindReplaceDialog
       this.pnlRegexpOptionsF.Controls.Add(this.chkEcmaScriptF);
       this.pnlRegexpOptionsF.Controls.Add(this.chkCultureInvariantF);
       this.pnlRegexpOptionsF.Controls.Add(this.chkCompiledF);
+      resources.ApplyResources(this.pnlRegexpOptionsF, "pnlRegexpOptionsF");
       this.pnlRegexpOptionsF.Name = "pnlRegexpOptionsF";
-      this.toolTip1.SetToolTip(this.pnlRegexpOptionsF, resources.GetString("pnlRegexpOptionsF.ToolTip"));
       // 
       // chkSinglelineF
       // 
       resources.ApplyResources(this.chkSinglelineF, "chkSinglelineF");
       this.chkSinglelineF.Name = "chkSinglelineF";
-      this.toolTip1.SetToolTip(this.chkSinglelineF, resources.GetString("chkSinglelineF.ToolTip"));
       this.chkSinglelineF.UseVisualStyleBackColor = true;
       // 
       // chkRightToLeftF
       // 
       resources.ApplyResources(this.chkRightToLeftF, "chkRightToLeftF");
       this.chkRightToLeftF.Name = "chkRightToLeftF";
-      this.toolTip1.SetToolTip(this.chkRightToLeftF, resources.GetString("chkRightToLeftF.ToolTip"));
       this.chkRightToLeftF.UseVisualStyleBackColor = true;
       // 
       // chkMultilineF
       // 
       resources.ApplyResources(this.chkMultilineF, "chkMultilineF");
       this.chkMultilineF.Name = "chkMultilineF";
-      this.toolTip1.SetToolTip(this.chkMultilineF, resources.GetString("chkMultilineF.ToolTip"));
       this.chkMultilineF.UseVisualStyleBackColor = true;
       // 
       // chkIgnorePatternWhitespaceF
       // 
       resources.ApplyResources(this.chkIgnorePatternWhitespaceF, "chkIgnorePatternWhitespaceF");
       this.chkIgnorePatternWhitespaceF.Name = "chkIgnorePatternWhitespaceF";
-      this.toolTip1.SetToolTip(this.chkIgnorePatternWhitespaceF, resources.GetString("chkIgnorePatternWhitespaceF.ToolTip"));
       this.chkIgnorePatternWhitespaceF.UseVisualStyleBackColor = true;
       // 
       // chkIgnoreCaseF
       // 
       resources.ApplyResources(this.chkIgnoreCaseF, "chkIgnoreCaseF");
       this.chkIgnoreCaseF.Name = "chkIgnoreCaseF";
-      this.toolTip1.SetToolTip(this.chkIgnoreCaseF, resources.GetString("chkIgnoreCaseF.ToolTip"));
       this.chkIgnoreCaseF.UseVisualStyleBackColor = true;
       // 
       // chkExplicitCaptureF
       // 
       resources.ApplyResources(this.chkExplicitCaptureF, "chkExplicitCaptureF");
       this.chkExplicitCaptureF.Name = "chkExplicitCaptureF";
-      this.toolTip1.SetToolTip(this.chkExplicitCaptureF, resources.GetString("chkExplicitCaptureF.ToolTip"));
       this.chkExplicitCaptureF.UseVisualStyleBackColor = true;
       // 
       // chkEcmaScriptF
       // 
       resources.ApplyResources(this.chkEcmaScriptF, "chkEcmaScriptF");
       this.chkEcmaScriptF.Name = "chkEcmaScriptF";
-      this.toolTip1.SetToolTip(this.chkEcmaScriptF, resources.GetString("chkEcmaScriptF.ToolTip"));
       this.chkEcmaScriptF.UseVisualStyleBackColor = true;
       this.chkEcmaScriptF.CheckedChanged += new System.EventHandler(this.chkEcmaScript_CheckedChanged);
       // 
@@ -443,27 +426,23 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.chkCultureInvariantF, "chkCultureInvariantF");
       this.chkCultureInvariantF.Name = "chkCultureInvariantF";
-      this.toolTip1.SetToolTip(this.chkCultureInvariantF, resources.GetString("chkCultureInvariantF.ToolTip"));
       this.chkCultureInvariantF.UseVisualStyleBackColor = true;
       // 
       // chkCompiledF
       // 
       resources.ApplyResources(this.chkCompiledF, "chkCompiledF");
       this.chkCompiledF.Name = "chkCompiledF";
-      this.toolTip1.SetToolTip(this.chkCompiledF, resources.GetString("chkCompiledF.ToolTip"));
       this.chkCompiledF.UseVisualStyleBackColor = true;
       // 
       // lblSearchTypeF
       // 
       resources.ApplyResources(this.lblSearchTypeF, "lblSearchTypeF");
       this.lblSearchTypeF.Name = "lblSearchTypeF";
-      this.toolTip1.SetToolTip(this.lblSearchTypeF, resources.GetString("lblSearchTypeF.ToolTip"));
       // 
       // rdoRegexF
       // 
       resources.ApplyResources(this.rdoRegexF, "rdoRegexF");
       this.rdoRegexF.Name = "rdoRegexF";
-      this.toolTip1.SetToolTip(this.rdoRegexF, resources.GetString("rdoRegexF.ToolTip"));
       this.rdoRegexF.UseVisualStyleBackColor = true;
       this.rdoRegexF.CheckedChanged += new System.EventHandler(this.rdoStandardF_CheckedChanged);
       // 
@@ -473,7 +452,6 @@ namespace ScintillaNET_FindReplaceDialog
       this.rdoStandardF.Checked = true;
       this.rdoStandardF.Name = "rdoStandardF";
       this.rdoStandardF.TabStop = true;
-      this.toolTip1.SetToolTip(this.rdoStandardF, resources.GetString("rdoStandardF.ToolTip"));
       this.rdoStandardF.UseVisualStyleBackColor = true;
       this.rdoStandardF.CheckedChanged += new System.EventHandler(this.rdoStandardF_CheckedChanged);
       // 
@@ -481,11 +459,9 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.lblFindF, "lblFindF");
       this.lblFindF.Name = "lblFindF";
-      this.toolTip1.SetToolTip(this.lblFindF, resources.GetString("lblFindF.ToolTip"));
       // 
       // tpgReplace
       // 
-      resources.ApplyResources(this.tpgReplace, "tpgReplace");
       this.tpgReplace.Controls.Add(this.btnFindNextR);
       this.tpgReplace.Controls.Add(this.btnFindPreviousR);
       this.tpgReplace.Controls.Add(this.txtReplace);
@@ -506,15 +482,14 @@ namespace ScintillaNET_FindReplaceDialog
       this.tpgReplace.Controls.Add(this.lblFindR);
       this.tpgReplace.Controls.Add(this.cmdRecentReplace);
       this.tpgReplace.Controls.Add(this.cmdRecentFindR);
+      resources.ApplyResources(this.tpgReplace, "tpgReplace");
       this.tpgReplace.Name = "tpgReplace";
-      this.toolTip1.SetToolTip(this.tpgReplace, resources.GetString("tpgReplace.ToolTip"));
       this.tpgReplace.UseVisualStyleBackColor = true;
       // 
       // btnFindNextR
       // 
       resources.ApplyResources(this.btnFindNextR, "btnFindNextR");
       this.btnFindNextR.Name = "btnFindNextR";
-      this.toolTip1.SetToolTip(this.btnFindNextR, resources.GetString("btnFindNextR.ToolTip"));
       this.btnFindNextR.UseVisualStyleBackColor = true;
       this.btnFindNextR.Click += new System.EventHandler(this.btnFindNext_Click);
       // 
@@ -522,7 +497,6 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.btnFindPreviousR, "btnFindPreviousR");
       this.btnFindPreviousR.Name = "btnFindPreviousR";
-      this.toolTip1.SetToolTip(this.btnFindPreviousR, resources.GetString("btnFindPreviousR.ToolTip"));
       this.btnFindPreviousR.UseVisualStyleBackColor = true;
       this.btnFindPreviousR.Click += new System.EventHandler(this.btnFindPrevious_Click);
       // 
@@ -530,13 +504,11 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.txtReplace, "txtReplace");
       this.txtReplace.Name = "txtReplace";
-      this.toolTip1.SetToolTip(this.txtReplace, resources.GetString("txtReplace.ToolTip"));
       // 
       // txtFindR
       // 
       resources.ApplyResources(this.txtFindR, "txtFindR");
       this.txtFindR.Name = "txtFindR";
-      this.toolTip1.SetToolTip(this.txtFindR, resources.GetString("txtFindR.ToolTip"));
       // 
       // cmdExtCharAndRegExReplace
       // 
@@ -558,7 +530,6 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.rdoExtendedR, "rdoExtendedR");
       this.rdoExtendedR.Name = "rdoExtendedR";
-      this.toolTip1.SetToolTip(this.rdoExtendedR, resources.GetString("rdoExtendedR.ToolTip"));
       this.rdoExtendedR.UseVisualStyleBackColor = true;
       this.rdoExtendedR.CheckedChanged += new System.EventHandler(this.rdoStandardR_CheckedChanged);
       // 
@@ -566,7 +537,6 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.btnReplaceAll, "btnReplaceAll");
       this.btnReplaceAll.Name = "btnReplaceAll";
-      this.toolTip1.SetToolTip(this.btnReplaceAll, resources.GetString("btnReplaceAll.ToolTip"));
       this.btnReplaceAll.UseVisualStyleBackColor = true;
       this.btnReplaceAll.Click += new System.EventHandler(this.btnReplaceAll_Click);
       // 
@@ -574,13 +544,11 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.lblReplace, "lblReplace");
       this.lblReplace.Name = "lblReplace";
-      this.toolTip1.SetToolTip(this.lblReplace, resources.GetString("lblReplace.ToolTip"));
       // 
       // chkSearchSelectionR
       // 
       resources.ApplyResources(this.chkSearchSelectionR, "chkSearchSelectionR");
       this.chkSearchSelectionR.Name = "chkSearchSelectionR";
-      this.toolTip1.SetToolTip(this.chkSearchSelectionR, resources.GetString("chkSearchSelectionR.ToolTip"));
       this.chkSearchSelectionR.UseVisualStyleBackColor = true;
       // 
       // chkWrapR
@@ -589,14 +557,12 @@ namespace ScintillaNET_FindReplaceDialog
       this.chkWrapR.Checked = true;
       this.chkWrapR.CheckState = System.Windows.Forms.CheckState.Checked;
       this.chkWrapR.Name = "chkWrapR";
-      this.toolTip1.SetToolTip(this.chkWrapR, resources.GetString("chkWrapR.ToolTip"));
       this.chkWrapR.UseVisualStyleBackColor = true;
       // 
       // btnReplacePrevious
       // 
       resources.ApplyResources(this.btnReplacePrevious, "btnReplacePrevious");
       this.btnReplacePrevious.Name = "btnReplacePrevious";
-      this.toolTip1.SetToolTip(this.btnReplacePrevious, resources.GetString("btnReplacePrevious.ToolTip"));
       this.btnReplacePrevious.UseVisualStyleBackColor = true;
       this.btnReplacePrevious.Click += new System.EventHandler(this.btnReplacePrevious_Click);
       // 
@@ -604,7 +570,6 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.btnReplaceNext, "btnReplaceNext");
       this.btnReplaceNext.Name = "btnReplaceNext";
-      this.toolTip1.SetToolTip(this.btnReplaceNext, resources.GetString("btnReplaceNext.ToolTip"));
       this.btnReplaceNext.UseVisualStyleBackColor = true;
       this.btnReplaceNext.Click += new System.EventHandler(this.btnReplaceNext_Click);
       // 
@@ -615,41 +580,35 @@ namespace ScintillaNET_FindReplaceDialog
       this.grdOptionsR.Controls.Add(this.pnlRegexpOptionsR);
       this.grdOptionsR.Name = "grdOptionsR";
       this.grdOptionsR.TabStop = false;
-      this.toolTip1.SetToolTip(this.grdOptionsR, resources.GetString("grdOptionsR.ToolTip"));
       // 
       // pnlStandardOptionsR
       // 
-      resources.ApplyResources(this.pnlStandardOptionsR, "pnlStandardOptionsR");
       this.pnlStandardOptionsR.Controls.Add(this.chkWordStartR);
       this.pnlStandardOptionsR.Controls.Add(this.chkWholeWordR);
       this.pnlStandardOptionsR.Controls.Add(this.chkMatchCaseR);
+      resources.ApplyResources(this.pnlStandardOptionsR, "pnlStandardOptionsR");
       this.pnlStandardOptionsR.Name = "pnlStandardOptionsR";
-      this.toolTip1.SetToolTip(this.pnlStandardOptionsR, resources.GetString("pnlStandardOptionsR.ToolTip"));
       // 
       // chkWordStartR
       // 
       resources.ApplyResources(this.chkWordStartR, "chkWordStartR");
       this.chkWordStartR.Name = "chkWordStartR";
-      this.toolTip1.SetToolTip(this.chkWordStartR, resources.GetString("chkWordStartR.ToolTip"));
       this.chkWordStartR.UseVisualStyleBackColor = true;
       // 
       // chkWholeWordR
       // 
       resources.ApplyResources(this.chkWholeWordR, "chkWholeWordR");
       this.chkWholeWordR.Name = "chkWholeWordR";
-      this.toolTip1.SetToolTip(this.chkWholeWordR, resources.GetString("chkWholeWordR.ToolTip"));
       this.chkWholeWordR.UseVisualStyleBackColor = true;
       // 
       // chkMatchCaseR
       // 
       resources.ApplyResources(this.chkMatchCaseR, "chkMatchCaseR");
       this.chkMatchCaseR.Name = "chkMatchCaseR";
-      this.toolTip1.SetToolTip(this.chkMatchCaseR, resources.GetString("chkMatchCaseR.ToolTip"));
       this.chkMatchCaseR.UseVisualStyleBackColor = true;
       // 
       // pnlRegexpOptionsR
       // 
-      resources.ApplyResources(this.pnlRegexpOptionsR, "pnlRegexpOptionsR");
       this.pnlRegexpOptionsR.Controls.Add(this.chkSinglelineR);
       this.pnlRegexpOptionsR.Controls.Add(this.chkRightToLeftR);
       this.pnlRegexpOptionsR.Controls.Add(this.chkMultilineR);
@@ -659,56 +618,49 @@ namespace ScintillaNET_FindReplaceDialog
       this.pnlRegexpOptionsR.Controls.Add(this.chkEcmaScriptR);
       this.pnlRegexpOptionsR.Controls.Add(this.chkCultureInvariantR);
       this.pnlRegexpOptionsR.Controls.Add(this.chkCompiledR);
+      resources.ApplyResources(this.pnlRegexpOptionsR, "pnlRegexpOptionsR");
       this.pnlRegexpOptionsR.Name = "pnlRegexpOptionsR";
-      this.toolTip1.SetToolTip(this.pnlRegexpOptionsR, resources.GetString("pnlRegexpOptionsR.ToolTip"));
       // 
       // chkSinglelineR
       // 
       resources.ApplyResources(this.chkSinglelineR, "chkSinglelineR");
       this.chkSinglelineR.Name = "chkSinglelineR";
-      this.toolTip1.SetToolTip(this.chkSinglelineR, resources.GetString("chkSinglelineR.ToolTip"));
       this.chkSinglelineR.UseVisualStyleBackColor = true;
       // 
       // chkRightToLeftR
       // 
       resources.ApplyResources(this.chkRightToLeftR, "chkRightToLeftR");
       this.chkRightToLeftR.Name = "chkRightToLeftR";
-      this.toolTip1.SetToolTip(this.chkRightToLeftR, resources.GetString("chkRightToLeftR.ToolTip"));
       this.chkRightToLeftR.UseVisualStyleBackColor = true;
       // 
       // chkMultilineR
       // 
       resources.ApplyResources(this.chkMultilineR, "chkMultilineR");
       this.chkMultilineR.Name = "chkMultilineR";
-      this.toolTip1.SetToolTip(this.chkMultilineR, resources.GetString("chkMultilineR.ToolTip"));
       this.chkMultilineR.UseVisualStyleBackColor = true;
       // 
       // chkIgnorePatternWhitespaceR
       // 
       resources.ApplyResources(this.chkIgnorePatternWhitespaceR, "chkIgnorePatternWhitespaceR");
       this.chkIgnorePatternWhitespaceR.Name = "chkIgnorePatternWhitespaceR";
-      this.toolTip1.SetToolTip(this.chkIgnorePatternWhitespaceR, resources.GetString("chkIgnorePatternWhitespaceR.ToolTip"));
       this.chkIgnorePatternWhitespaceR.UseVisualStyleBackColor = true;
       // 
       // chkIgnoreCaseR
       // 
       resources.ApplyResources(this.chkIgnoreCaseR, "chkIgnoreCaseR");
       this.chkIgnoreCaseR.Name = "chkIgnoreCaseR";
-      this.toolTip1.SetToolTip(this.chkIgnoreCaseR, resources.GetString("chkIgnoreCaseR.ToolTip"));
       this.chkIgnoreCaseR.UseVisualStyleBackColor = true;
       // 
       // chkExplicitCaptureR
       // 
       resources.ApplyResources(this.chkExplicitCaptureR, "chkExplicitCaptureR");
       this.chkExplicitCaptureR.Name = "chkExplicitCaptureR";
-      this.toolTip1.SetToolTip(this.chkExplicitCaptureR, resources.GetString("chkExplicitCaptureR.ToolTip"));
       this.chkExplicitCaptureR.UseVisualStyleBackColor = true;
       // 
       // chkEcmaScriptR
       // 
       resources.ApplyResources(this.chkEcmaScriptR, "chkEcmaScriptR");
       this.chkEcmaScriptR.Name = "chkEcmaScriptR";
-      this.toolTip1.SetToolTip(this.chkEcmaScriptR, resources.GetString("chkEcmaScriptR.ToolTip"));
       this.chkEcmaScriptR.UseVisualStyleBackColor = true;
       this.chkEcmaScriptR.CheckedChanged += new System.EventHandler(this.chkEcmaScript_CheckedChanged);
       // 
@@ -716,27 +668,23 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.chkCultureInvariantR, "chkCultureInvariantR");
       this.chkCultureInvariantR.Name = "chkCultureInvariantR";
-      this.toolTip1.SetToolTip(this.chkCultureInvariantR, resources.GetString("chkCultureInvariantR.ToolTip"));
       this.chkCultureInvariantR.UseVisualStyleBackColor = true;
       // 
       // chkCompiledR
       // 
       resources.ApplyResources(this.chkCompiledR, "chkCompiledR");
       this.chkCompiledR.Name = "chkCompiledR";
-      this.toolTip1.SetToolTip(this.chkCompiledR, resources.GetString("chkCompiledR.ToolTip"));
       this.chkCompiledR.UseVisualStyleBackColor = true;
       // 
       // lblSearchTypeR
       // 
       resources.ApplyResources(this.lblSearchTypeR, "lblSearchTypeR");
       this.lblSearchTypeR.Name = "lblSearchTypeR";
-      this.toolTip1.SetToolTip(this.lblSearchTypeR, resources.GetString("lblSearchTypeR.ToolTip"));
       // 
       // rdoRegexR
       // 
       resources.ApplyResources(this.rdoRegexR, "rdoRegexR");
       this.rdoRegexR.Name = "rdoRegexR";
-      this.toolTip1.SetToolTip(this.rdoRegexR, resources.GetString("rdoRegexR.ToolTip"));
       this.rdoRegexR.UseVisualStyleBackColor = true;
       this.rdoRegexR.CheckedChanged += new System.EventHandler(this.rdoStandardR_CheckedChanged);
       // 
@@ -746,7 +694,6 @@ namespace ScintillaNET_FindReplaceDialog
       this.rdoStandardR.Checked = true;
       this.rdoStandardR.Name = "rdoStandardR";
       this.rdoStandardR.TabStop = true;
-      this.toolTip1.SetToolTip(this.rdoStandardR, resources.GetString("rdoStandardR.ToolTip"));
       this.rdoStandardR.UseVisualStyleBackColor = true;
       this.rdoStandardR.CheckedChanged += new System.EventHandler(this.rdoStandardR_CheckedChanged);
       // 
@@ -754,7 +701,6 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       resources.ApplyResources(this.lblFindR, "lblFindR");
       this.lblFindR.Name = "lblFindR";
-      this.toolTip1.SetToolTip(this.lblFindR, resources.GetString("lblFindR.ToolTip"));
       // 
       // cmdRecentReplace
       // 
@@ -776,20 +722,18 @@ namespace ScintillaNET_FindReplaceDialog
       // 
       // statusStrip
       // 
-      resources.ApplyResources(this.statusStrip, "statusStrip");
       this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.lblStatus});
+      resources.ApplyResources(this.statusStrip, "statusStrip");
       this.statusStrip.Name = "statusStrip";
-      this.toolTip1.SetToolTip(this.statusStrip, resources.GetString("statusStrip.ToolTip"));
       // 
       // lblStatus
       // 
-      resources.ApplyResources(this.lblStatus, "lblStatus");
       this.lblStatus.Name = "lblStatus";
+      resources.ApplyResources(this.lblStatus, "lblStatus");
       // 
       // mnuExtendedCharFindF
       // 
-      resources.ApplyResources(this.mnuExtendedCharFindF, "mnuExtendedCharFindF");
       this.mnuExtendedCharFindF.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem13,
             this.nNewLineToolStripMenuItem,
@@ -798,50 +742,51 @@ namespace ScintillaNET_FindReplaceDialog
             this.nullCharactorToolStripMenuItem});
       this.mnuExtendedCharFindF.Name = "contextMenuStrip1";
       this.mnuExtendedCharFindF.ShowImageMargin = false;
-      this.toolTip1.SetToolTip(this.mnuExtendedCharFindF, resources.GetString("mnuExtendedCharFindF.ToolTip"));
+      resources.ApplyResources(this.mnuExtendedCharFindF, "mnuExtendedCharFindF");
       this.mnuExtendedCharFindF.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.contextMenuStrip1_ItemClicked);
       // 
       // toolStripMenuItem13
       // 
-      resources.ApplyResources(this.toolStripMenuItem13, "toolStripMenuItem13");
       this.toolStripMenuItem13.Name = "toolStripMenuItem13";
+      resources.ApplyResources(this.toolStripMenuItem13, "toolStripMenuItem13");
       this.toolStripMenuItem13.Tag = "\\r\\n";
       // 
       // nNewLineToolStripMenuItem
       // 
-      resources.ApplyResources(this.nNewLineToolStripMenuItem, "nNewLineToolStripMenuItem");
       this.nNewLineToolStripMenuItem.Name = "nNewLineToolStripMenuItem";
+      resources.ApplyResources(this.nNewLineToolStripMenuItem, "nNewLineToolStripMenuItem");
       this.nNewLineToolStripMenuItem.Tag = "\\n";
       // 
       // rCarriageToolStripMenuItem
       // 
-      resources.ApplyResources(this.rCarriageToolStripMenuItem, "rCarriageToolStripMenuItem");
       this.rCarriageToolStripMenuItem.Name = "rCarriageToolStripMenuItem";
+      resources.ApplyResources(this.rCarriageToolStripMenuItem, "rCarriageToolStripMenuItem");
       this.rCarriageToolStripMenuItem.Tag = "\\r";
       // 
       // tTabToolStripMenuItem1
       // 
-      resources.ApplyResources(this.tTabToolStripMenuItem1, "tTabToolStripMenuItem1");
       this.tTabToolStripMenuItem1.Name = "tTabToolStripMenuItem1";
+      resources.ApplyResources(this.tTabToolStripMenuItem1, "tTabToolStripMenuItem1");
       this.tTabToolStripMenuItem1.Tag = "\\t";
       // 
       // nullCharactorToolStripMenuItem
       // 
-      resources.ApplyResources(this.nullCharactorToolStripMenuItem, "nullCharactorToolStripMenuItem");
       this.nullCharactorToolStripMenuItem.Name = "nullCharactorToolStripMenuItem";
+      resources.ApplyResources(this.nullCharactorToolStripMenuItem, "nullCharactorToolStripMenuItem");
       this.nullCharactorToolStripMenuItem.Tag = "\\0";
       // 
       // mnuRecentFindF
       // 
-      resources.ApplyResources(this.mnuRecentFindF, "mnuRecentFindF");
+      this.mnuRecentFindF.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripSeparator9,
+            this.clearHistoryToolStripMenuItemFindF});
       this.mnuRecentFindF.Name = "contextMenuStrip1";
       this.mnuRecentFindF.ShowImageMargin = false;
-      this.toolTip1.SetToolTip(this.mnuRecentFindF, resources.GetString("mnuRecentFindF.ToolTip"));
+      resources.ApplyResources(this.mnuRecentFindF, "mnuRecentFindF");
       this.mnuRecentFindF.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.mnuRecentFindF_ItemClicked);
       // 
       // mnuExtendedCharFindR
       // 
-      resources.ApplyResources(this.mnuExtendedCharFindR, "mnuExtendedCharFindR");
       this.mnuExtendedCharFindR.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem14,
             this.toolStripMenuItem1,
@@ -850,42 +795,41 @@ namespace ScintillaNET_FindReplaceDialog
             this.toolStripMenuItem4});
       this.mnuExtendedCharFindR.Name = "contextMenuStrip1";
       this.mnuExtendedCharFindR.ShowImageMargin = false;
-      this.toolTip1.SetToolTip(this.mnuExtendedCharFindR, resources.GetString("mnuExtendedCharFindR.ToolTip"));
+      resources.ApplyResources(this.mnuExtendedCharFindR, "mnuExtendedCharFindR");
       this.mnuExtendedCharFindR.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.mnuExtendedCharFindR_ItemClicked);
       // 
       // toolStripMenuItem14
       // 
-      resources.ApplyResources(this.toolStripMenuItem14, "toolStripMenuItem14");
       this.toolStripMenuItem14.Name = "toolStripMenuItem14";
+      resources.ApplyResources(this.toolStripMenuItem14, "toolStripMenuItem14");
       this.toolStripMenuItem14.Tag = "\\r\\n";
       // 
       // toolStripMenuItem1
       // 
-      resources.ApplyResources(this.toolStripMenuItem1, "toolStripMenuItem1");
       this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+      resources.ApplyResources(this.toolStripMenuItem1, "toolStripMenuItem1");
       this.toolStripMenuItem1.Tag = "\\n";
       // 
       // toolStripMenuItem2
       // 
-      resources.ApplyResources(this.toolStripMenuItem2, "toolStripMenuItem2");
       this.toolStripMenuItem2.Name = "toolStripMenuItem2";
+      resources.ApplyResources(this.toolStripMenuItem2, "toolStripMenuItem2");
       this.toolStripMenuItem2.Tag = "\\r";
       // 
       // toolStripMenuItem3
       // 
-      resources.ApplyResources(this.toolStripMenuItem3, "toolStripMenuItem3");
       this.toolStripMenuItem3.Name = "toolStripMenuItem3";
+      resources.ApplyResources(this.toolStripMenuItem3, "toolStripMenuItem3");
       this.toolStripMenuItem3.Tag = "\\t";
       // 
       // toolStripMenuItem4
       // 
-      resources.ApplyResources(this.toolStripMenuItem4, "toolStripMenuItem4");
       this.toolStripMenuItem4.Name = "toolStripMenuItem4";
+      resources.ApplyResources(this.toolStripMenuItem4, "toolStripMenuItem4");
       this.toolStripMenuItem4.Tag = "\\0";
       // 
       // mnuExtendedCharReplace
       // 
-      resources.ApplyResources(this.mnuExtendedCharReplace, "mnuExtendedCharReplace");
       this.mnuExtendedCharReplace.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem15,
             this.toolStripMenuItem5,
@@ -894,58 +838,61 @@ namespace ScintillaNET_FindReplaceDialog
             this.toolStripMenuItem8});
       this.mnuExtendedCharReplace.Name = "contextMenuStrip1";
       this.mnuExtendedCharReplace.ShowImageMargin = false;
-      this.toolTip1.SetToolTip(this.mnuExtendedCharReplace, resources.GetString("mnuExtendedCharReplace.ToolTip"));
+      resources.ApplyResources(this.mnuExtendedCharReplace, "mnuExtendedCharReplace");
       this.mnuExtendedCharReplace.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.mnuExtendedCharReplace_ItemClicked);
       // 
       // toolStripMenuItem15
       // 
-      resources.ApplyResources(this.toolStripMenuItem15, "toolStripMenuItem15");
       this.toolStripMenuItem15.Name = "toolStripMenuItem15";
+      resources.ApplyResources(this.toolStripMenuItem15, "toolStripMenuItem15");
       this.toolStripMenuItem15.Tag = "\\r\\n";
       // 
       // toolStripMenuItem5
       // 
-      resources.ApplyResources(this.toolStripMenuItem5, "toolStripMenuItem5");
       this.toolStripMenuItem5.Name = "toolStripMenuItem5";
+      resources.ApplyResources(this.toolStripMenuItem5, "toolStripMenuItem5");
       this.toolStripMenuItem5.Tag = "\\n";
       // 
       // toolStripMenuItem6
       // 
-      resources.ApplyResources(this.toolStripMenuItem6, "toolStripMenuItem6");
       this.toolStripMenuItem6.Name = "toolStripMenuItem6";
+      resources.ApplyResources(this.toolStripMenuItem6, "toolStripMenuItem6");
       this.toolStripMenuItem6.Tag = "\\r";
       // 
       // toolStripMenuItem7
       // 
-      resources.ApplyResources(this.toolStripMenuItem7, "toolStripMenuItem7");
       this.toolStripMenuItem7.Name = "toolStripMenuItem7";
+      resources.ApplyResources(this.toolStripMenuItem7, "toolStripMenuItem7");
       this.toolStripMenuItem7.Tag = "\\t";
       // 
       // toolStripMenuItem8
       // 
-      resources.ApplyResources(this.toolStripMenuItem8, "toolStripMenuItem8");
       this.toolStripMenuItem8.Name = "toolStripMenuItem8";
+      resources.ApplyResources(this.toolStripMenuItem8, "toolStripMenuItem8");
       this.toolStripMenuItem8.Tag = "\\0";
       // 
       // mnuRecentFindR
       // 
-      resources.ApplyResources(this.mnuRecentFindR, "mnuRecentFindR");
+      this.mnuRecentFindR.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripSeparator10,
+            this.clearHistoryToolStripMenuItemFindR});
       this.mnuRecentFindR.Name = "contextMenuStrip1";
       this.mnuRecentFindR.ShowImageMargin = false;
-      this.toolTip1.SetToolTip(this.mnuRecentFindR, resources.GetString("mnuRecentFindR.ToolTip"));
+      resources.ApplyResources(this.mnuRecentFindR, "mnuRecentFindR");
       this.mnuRecentFindR.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.mnuRecentFindR_ItemClicked);
       // 
       // mnuRecentReplace
       // 
-      resources.ApplyResources(this.mnuRecentReplace, "mnuRecentReplace");
+      this.mnuRecentReplace.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripSeparator11,
+            this.clearHistoryToolStripMenuItemReplace});
       this.mnuRecentReplace.Name = "contextMenuStrip1";
       this.mnuRecentReplace.ShowImageMargin = false;
-      this.toolTip1.SetToolTip(this.mnuRecentReplace, resources.GetString("mnuRecentReplace.ToolTip"));
+      resources.ApplyResources(this.mnuRecentReplace, "mnuRecentReplace");
       this.mnuRecentReplace.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.mnuRecentReplace_ItemClicked);
       // 
       // mnuRegExCharFindF
       // 
-      resources.ApplyResources(this.mnuRegExCharFindF, "mnuRegExCharFindF");
       this.mnuRegExCharFindF.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem9,
             this.toolStripMenuItem10,
@@ -971,139 +918,138 @@ namespace ScintillaNET_FindReplaceDialog
             this.toolStripMenuItem24});
       this.mnuRegExCharFindF.Name = "contextMenuStrip1";
       this.mnuRegExCharFindF.ShowImageMargin = false;
-      this.toolTip1.SetToolTip(this.mnuRegExCharFindF, resources.GetString("mnuRegExCharFindF.ToolTip"));
+      resources.ApplyResources(this.mnuRegExCharFindF, "mnuRegExCharFindF");
       // 
       // toolStripMenuItem9
       // 
-      resources.ApplyResources(this.toolStripMenuItem9, "toolStripMenuItem9");
       this.toolStripMenuItem9.Name = "toolStripMenuItem9";
+      resources.ApplyResources(this.toolStripMenuItem9, "toolStripMenuItem9");
       this.toolStripMenuItem9.Tag = ".";
       // 
       // toolStripMenuItem10
       // 
-      resources.ApplyResources(this.toolStripMenuItem10, "toolStripMenuItem10");
       this.toolStripMenuItem10.Name = "toolStripMenuItem10";
+      resources.ApplyResources(this.toolStripMenuItem10, "toolStripMenuItem10");
       this.toolStripMenuItem10.Tag = "\\w";
       // 
       // toolStripMenuItem11
       // 
-      resources.ApplyResources(this.toolStripMenuItem11, "toolStripMenuItem11");
       this.toolStripMenuItem11.Name = "toolStripMenuItem11";
+      resources.ApplyResources(this.toolStripMenuItem11, "toolStripMenuItem11");
       this.toolStripMenuItem11.Tag = "\\d";
       // 
       // toolStripMenuItem12
       // 
-      resources.ApplyResources(this.toolStripMenuItem12, "toolStripMenuItem12");
       this.toolStripMenuItem12.Name = "toolStripMenuItem12";
+      resources.ApplyResources(this.toolStripMenuItem12, "toolStripMenuItem12");
       this.toolStripMenuItem12.Tag = "\\s";
       // 
       // toolStripMenuItem16
       // 
-      resources.ApplyResources(this.toolStripMenuItem16, "toolStripMenuItem16");
       this.toolStripMenuItem16.Name = "toolStripMenuItem16";
+      resources.ApplyResources(this.toolStripMenuItem16, "toolStripMenuItem16");
       this.toolStripMenuItem16.Tag = "[a-zA-Z]";
       // 
       // toolStripSeparator4
       // 
-      resources.ApplyResources(this.toolStripSeparator4, "toolStripSeparator4");
       this.toolStripSeparator4.Name = "toolStripSeparator4";
+      resources.ApplyResources(this.toolStripSeparator4, "toolStripSeparator4");
       // 
       // toolStripMenuItem25
       // 
-      resources.ApplyResources(this.toolStripMenuItem25, "toolStripMenuItem25");
       this.toolStripMenuItem25.Name = "toolStripMenuItem25";
+      resources.ApplyResources(this.toolStripMenuItem25, "toolStripMenuItem25");
       this.toolStripMenuItem25.Tag = "\\r\\n";
       // 
       // toolStripMenuItem26
       // 
-      resources.ApplyResources(this.toolStripMenuItem26, "toolStripMenuItem26");
       this.toolStripMenuItem26.Name = "toolStripMenuItem26";
+      resources.ApplyResources(this.toolStripMenuItem26, "toolStripMenuItem26");
       this.toolStripMenuItem26.Tag = "\\n";
       // 
       // toolStripMenuItem27
       // 
-      resources.ApplyResources(this.toolStripMenuItem27, "toolStripMenuItem27");
       this.toolStripMenuItem27.Name = "toolStripMenuItem27";
+      resources.ApplyResources(this.toolStripMenuItem27, "toolStripMenuItem27");
       this.toolStripMenuItem27.Tag = "\\r";
       // 
       // toolStripMenuItem28
       // 
-      resources.ApplyResources(this.toolStripMenuItem28, "toolStripMenuItem28");
       this.toolStripMenuItem28.Name = "toolStripMenuItem28";
+      resources.ApplyResources(this.toolStripMenuItem28, "toolStripMenuItem28");
       this.toolStripMenuItem28.Tag = "\\t";
       // 
       // toolStripMenuItem29
       // 
-      resources.ApplyResources(this.toolStripMenuItem29, "toolStripMenuItem29");
       this.toolStripMenuItem29.Name = "toolStripMenuItem29";
+      resources.ApplyResources(this.toolStripMenuItem29, "toolStripMenuItem29");
       this.toolStripMenuItem29.Tag = "\\0";
       // 
       // toolStripSeparator1
       // 
-      resources.ApplyResources(this.toolStripSeparator1, "toolStripSeparator1");
       this.toolStripSeparator1.Name = "toolStripSeparator1";
+      resources.ApplyResources(this.toolStripSeparator1, "toolStripSeparator1");
       // 
       // toolStripMenuItem17
       // 
-      resources.ApplyResources(this.toolStripMenuItem17, "toolStripMenuItem17");
       this.toolStripMenuItem17.Name = "toolStripMenuItem17";
+      resources.ApplyResources(this.toolStripMenuItem17, "toolStripMenuItem17");
       this.toolStripMenuItem17.Tag = "*";
       // 
       // toolStripMenuItem18
       // 
-      resources.ApplyResources(this.toolStripMenuItem18, "toolStripMenuItem18");
       this.toolStripMenuItem18.Name = "toolStripMenuItem18";
+      resources.ApplyResources(this.toolStripMenuItem18, "toolStripMenuItem18");
       this.toolStripMenuItem18.Tag = "+";
       // 
       // toolStripMenuItem19
       // 
-      resources.ApplyResources(this.toolStripMenuItem19, "toolStripMenuItem19");
       this.toolStripMenuItem19.Name = "toolStripMenuItem19";
+      resources.ApplyResources(this.toolStripMenuItem19, "toolStripMenuItem19");
       this.toolStripMenuItem19.Tag = "?";
       // 
       // toolStripMenuItem22
       // 
-      resources.ApplyResources(this.toolStripMenuItem22, "toolStripMenuItem22");
       this.toolStripMenuItem22.Name = "toolStripMenuItem22";
+      resources.ApplyResources(this.toolStripMenuItem22, "toolStripMenuItem22");
       this.toolStripMenuItem22.Tag = "?";
       // 
       // toolStripSeparator2
       // 
-      resources.ApplyResources(this.toolStripSeparator2, "toolStripSeparator2");
       this.toolStripSeparator2.Name = "toolStripSeparator2";
+      resources.ApplyResources(this.toolStripSeparator2, "toolStripSeparator2");
       // 
       // toolStripMenuItem20
       // 
-      resources.ApplyResources(this.toolStripMenuItem20, "toolStripMenuItem20");
       this.toolStripMenuItem20.Name = "toolStripMenuItem20";
+      resources.ApplyResources(this.toolStripMenuItem20, "toolStripMenuItem20");
       this.toolStripMenuItem20.Tag = "()";
       // 
       // toolStripMenuItem21
       // 
-      resources.ApplyResources(this.toolStripMenuItem21, "toolStripMenuItem21");
       this.toolStripMenuItem21.Name = "toolStripMenuItem21";
+      resources.ApplyResources(this.toolStripMenuItem21, "toolStripMenuItem21");
       this.toolStripMenuItem21.Tag = "(?<Name>)";
       // 
       // toolStripSeparator3
       // 
-      resources.ApplyResources(this.toolStripSeparator3, "toolStripSeparator3");
       this.toolStripSeparator3.Name = "toolStripSeparator3";
+      resources.ApplyResources(this.toolStripSeparator3, "toolStripSeparator3");
       // 
       // toolStripMenuItem23
       // 
-      resources.ApplyResources(this.toolStripMenuItem23, "toolStripMenuItem23");
       this.toolStripMenuItem23.Name = "toolStripMenuItem23";
+      resources.ApplyResources(this.toolStripMenuItem23, "toolStripMenuItem23");
       this.toolStripMenuItem23.Tag = "^";
       // 
       // toolStripMenuItem24
       // 
-      resources.ApplyResources(this.toolStripMenuItem24, "toolStripMenuItem24");
       this.toolStripMenuItem24.Name = "toolStripMenuItem24";
+      resources.ApplyResources(this.toolStripMenuItem24, "toolStripMenuItem24");
       this.toolStripMenuItem24.Tag = "$";
       // 
       // mnuRegExCharFindR
       // 
-      resources.ApplyResources(this.mnuRegExCharFindR, "mnuRegExCharFindR");
       this.mnuRegExCharFindR.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem30,
             this.toolStripMenuItem31,
@@ -1129,139 +1075,138 @@ namespace ScintillaNET_FindReplaceDialog
             this.toolStripMenuItem47});
       this.mnuRegExCharFindR.Name = "contextMenuStrip1";
       this.mnuRegExCharFindR.ShowImageMargin = false;
-      this.toolTip1.SetToolTip(this.mnuRegExCharFindR, resources.GetString("mnuRegExCharFindR.ToolTip"));
+      resources.ApplyResources(this.mnuRegExCharFindR, "mnuRegExCharFindR");
       // 
       // toolStripMenuItem30
       // 
-      resources.ApplyResources(this.toolStripMenuItem30, "toolStripMenuItem30");
       this.toolStripMenuItem30.Name = "toolStripMenuItem30";
+      resources.ApplyResources(this.toolStripMenuItem30, "toolStripMenuItem30");
       this.toolStripMenuItem30.Tag = ".";
       // 
       // toolStripMenuItem31
       // 
-      resources.ApplyResources(this.toolStripMenuItem31, "toolStripMenuItem31");
       this.toolStripMenuItem31.Name = "toolStripMenuItem31";
+      resources.ApplyResources(this.toolStripMenuItem31, "toolStripMenuItem31");
       this.toolStripMenuItem31.Tag = "\\w";
       // 
       // toolStripMenuItem32
       // 
-      resources.ApplyResources(this.toolStripMenuItem32, "toolStripMenuItem32");
       this.toolStripMenuItem32.Name = "toolStripMenuItem32";
+      resources.ApplyResources(this.toolStripMenuItem32, "toolStripMenuItem32");
       this.toolStripMenuItem32.Tag = "\\d";
       // 
       // toolStripMenuItem33
       // 
-      resources.ApplyResources(this.toolStripMenuItem33, "toolStripMenuItem33");
       this.toolStripMenuItem33.Name = "toolStripMenuItem33";
+      resources.ApplyResources(this.toolStripMenuItem33, "toolStripMenuItem33");
       this.toolStripMenuItem33.Tag = "\\s";
       // 
       // toolStripMenuItem34
       // 
-      resources.ApplyResources(this.toolStripMenuItem34, "toolStripMenuItem34");
       this.toolStripMenuItem34.Name = "toolStripMenuItem34";
+      resources.ApplyResources(this.toolStripMenuItem34, "toolStripMenuItem34");
       this.toolStripMenuItem34.Tag = "[a-zA-Z]";
       // 
       // toolStripSeparator5
       // 
-      resources.ApplyResources(this.toolStripSeparator5, "toolStripSeparator5");
       this.toolStripSeparator5.Name = "toolStripSeparator5";
+      resources.ApplyResources(this.toolStripSeparator5, "toolStripSeparator5");
       // 
       // toolStripMenuItem35
       // 
-      resources.ApplyResources(this.toolStripMenuItem35, "toolStripMenuItem35");
       this.toolStripMenuItem35.Name = "toolStripMenuItem35";
+      resources.ApplyResources(this.toolStripMenuItem35, "toolStripMenuItem35");
       this.toolStripMenuItem35.Tag = "\\r\\n";
       // 
       // toolStripMenuItem36
       // 
-      resources.ApplyResources(this.toolStripMenuItem36, "toolStripMenuItem36");
       this.toolStripMenuItem36.Name = "toolStripMenuItem36";
+      resources.ApplyResources(this.toolStripMenuItem36, "toolStripMenuItem36");
       this.toolStripMenuItem36.Tag = "\\n";
       // 
       // toolStripMenuItem37
       // 
-      resources.ApplyResources(this.toolStripMenuItem37, "toolStripMenuItem37");
       this.toolStripMenuItem37.Name = "toolStripMenuItem37";
+      resources.ApplyResources(this.toolStripMenuItem37, "toolStripMenuItem37");
       this.toolStripMenuItem37.Tag = "\\r";
       // 
       // toolStripMenuItem38
       // 
-      resources.ApplyResources(this.toolStripMenuItem38, "toolStripMenuItem38");
       this.toolStripMenuItem38.Name = "toolStripMenuItem38";
+      resources.ApplyResources(this.toolStripMenuItem38, "toolStripMenuItem38");
       this.toolStripMenuItem38.Tag = "\\t";
       // 
       // toolStripMenuItem39
       // 
-      resources.ApplyResources(this.toolStripMenuItem39, "toolStripMenuItem39");
       this.toolStripMenuItem39.Name = "toolStripMenuItem39";
+      resources.ApplyResources(this.toolStripMenuItem39, "toolStripMenuItem39");
       this.toolStripMenuItem39.Tag = "\\0";
       // 
       // toolStripSeparator6
       // 
-      resources.ApplyResources(this.toolStripSeparator6, "toolStripSeparator6");
       this.toolStripSeparator6.Name = "toolStripSeparator6";
+      resources.ApplyResources(this.toolStripSeparator6, "toolStripSeparator6");
       // 
       // toolStripMenuItem40
       // 
-      resources.ApplyResources(this.toolStripMenuItem40, "toolStripMenuItem40");
       this.toolStripMenuItem40.Name = "toolStripMenuItem40";
+      resources.ApplyResources(this.toolStripMenuItem40, "toolStripMenuItem40");
       this.toolStripMenuItem40.Tag = "*";
       // 
       // toolStripMenuItem41
       // 
-      resources.ApplyResources(this.toolStripMenuItem41, "toolStripMenuItem41");
       this.toolStripMenuItem41.Name = "toolStripMenuItem41";
+      resources.ApplyResources(this.toolStripMenuItem41, "toolStripMenuItem41");
       this.toolStripMenuItem41.Tag = "+";
       // 
       // toolStripMenuItem42
       // 
-      resources.ApplyResources(this.toolStripMenuItem42, "toolStripMenuItem42");
       this.toolStripMenuItem42.Name = "toolStripMenuItem42";
+      resources.ApplyResources(this.toolStripMenuItem42, "toolStripMenuItem42");
       this.toolStripMenuItem42.Tag = "?";
       // 
       // toolStripMenuItem43
       // 
-      resources.ApplyResources(this.toolStripMenuItem43, "toolStripMenuItem43");
       this.toolStripMenuItem43.Name = "toolStripMenuItem43";
+      resources.ApplyResources(this.toolStripMenuItem43, "toolStripMenuItem43");
       this.toolStripMenuItem43.Tag = "?";
       // 
       // toolStripSeparator7
       // 
-      resources.ApplyResources(this.toolStripSeparator7, "toolStripSeparator7");
       this.toolStripSeparator7.Name = "toolStripSeparator7";
+      resources.ApplyResources(this.toolStripSeparator7, "toolStripSeparator7");
       // 
       // toolStripMenuItem44
       // 
-      resources.ApplyResources(this.toolStripMenuItem44, "toolStripMenuItem44");
       this.toolStripMenuItem44.Name = "toolStripMenuItem44";
+      resources.ApplyResources(this.toolStripMenuItem44, "toolStripMenuItem44");
       this.toolStripMenuItem44.Tag = "()";
       // 
       // toolStripMenuItem45
       // 
-      resources.ApplyResources(this.toolStripMenuItem45, "toolStripMenuItem45");
       this.toolStripMenuItem45.Name = "toolStripMenuItem45";
+      resources.ApplyResources(this.toolStripMenuItem45, "toolStripMenuItem45");
       this.toolStripMenuItem45.Tag = "(?<Name>)";
       // 
       // toolStripSeparator8
       // 
-      resources.ApplyResources(this.toolStripSeparator8, "toolStripSeparator8");
       this.toolStripSeparator8.Name = "toolStripSeparator8";
+      resources.ApplyResources(this.toolStripSeparator8, "toolStripSeparator8");
       // 
       // toolStripMenuItem46
       // 
-      resources.ApplyResources(this.toolStripMenuItem46, "toolStripMenuItem46");
       this.toolStripMenuItem46.Name = "toolStripMenuItem46";
+      resources.ApplyResources(this.toolStripMenuItem46, "toolStripMenuItem46");
       this.toolStripMenuItem46.Tag = "^";
       // 
       // toolStripMenuItem47
       // 
-      resources.ApplyResources(this.toolStripMenuItem47, "toolStripMenuItem47");
       this.toolStripMenuItem47.Name = "toolStripMenuItem47";
+      resources.ApplyResources(this.toolStripMenuItem47, "toolStripMenuItem47");
       this.toolStripMenuItem47.Tag = "$";
       // 
       // mnuRegExCharReplace
       // 
-      resources.ApplyResources(this.mnuRegExCharReplace, "mnuRegExCharReplace");
       this.mnuRegExCharReplace.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripMenuItem48,
             this.toolStripMenuItem49,
@@ -1276,72 +1221,102 @@ namespace ScintillaNET_FindReplaceDialog
             this.nameToolStripMenuItem});
       this.mnuRegExCharReplace.Name = "contextMenuStrip1";
       this.mnuRegExCharReplace.ShowImageMargin = false;
-      this.toolTip1.SetToolTip(this.mnuRegExCharReplace, resources.GetString("mnuRegExCharReplace.ToolTip"));
+      resources.ApplyResources(this.mnuRegExCharReplace, "mnuRegExCharReplace");
       // 
       // toolStripMenuItem48
       // 
-      resources.ApplyResources(this.toolStripMenuItem48, "toolStripMenuItem48");
       this.toolStripMenuItem48.Name = "toolStripMenuItem48";
+      resources.ApplyResources(this.toolStripMenuItem48, "toolStripMenuItem48");
       this.toolStripMenuItem48.Tag = "$&";
       // 
       // toolStripMenuItem49
       // 
-      resources.ApplyResources(this.toolStripMenuItem49, "toolStripMenuItem49");
       this.toolStripMenuItem49.Name = "toolStripMenuItem49";
+      resources.ApplyResources(this.toolStripMenuItem49, "toolStripMenuItem49");
       this.toolStripMenuItem49.Tag = "$1";
       // 
       // toolStripMenuItem57
       // 
-      resources.ApplyResources(this.toolStripMenuItem57, "toolStripMenuItem57");
       this.toolStripMenuItem57.Name = "toolStripMenuItem57";
+      resources.ApplyResources(this.toolStripMenuItem57, "toolStripMenuItem57");
       this.toolStripMenuItem57.Tag = "$2";
       // 
       // toolStripMenuItem56
       // 
-      resources.ApplyResources(this.toolStripMenuItem56, "toolStripMenuItem56");
       this.toolStripMenuItem56.Name = "toolStripMenuItem56";
+      resources.ApplyResources(this.toolStripMenuItem56, "toolStripMenuItem56");
       this.toolStripMenuItem56.Tag = "$3";
       // 
       // toolStripMenuItem55
       // 
-      resources.ApplyResources(this.toolStripMenuItem55, "toolStripMenuItem55");
       this.toolStripMenuItem55.Name = "toolStripMenuItem55";
+      resources.ApplyResources(this.toolStripMenuItem55, "toolStripMenuItem55");
       this.toolStripMenuItem55.Tag = "$4";
       // 
       // toolStripMenuItem54
       // 
-      resources.ApplyResources(this.toolStripMenuItem54, "toolStripMenuItem54");
       this.toolStripMenuItem54.Name = "toolStripMenuItem54";
+      resources.ApplyResources(this.toolStripMenuItem54, "toolStripMenuItem54");
       this.toolStripMenuItem54.Tag = "$5";
       // 
       // toolStripMenuItem53
       // 
-      resources.ApplyResources(this.toolStripMenuItem53, "toolStripMenuItem53");
       this.toolStripMenuItem53.Name = "toolStripMenuItem53";
+      resources.ApplyResources(this.toolStripMenuItem53, "toolStripMenuItem53");
       this.toolStripMenuItem53.Tag = "$6";
       // 
       // toolStripMenuItem52
       // 
-      resources.ApplyResources(this.toolStripMenuItem52, "toolStripMenuItem52");
       this.toolStripMenuItem52.Name = "toolStripMenuItem52";
+      resources.ApplyResources(this.toolStripMenuItem52, "toolStripMenuItem52");
       this.toolStripMenuItem52.Tag = "$7";
       // 
       // toolStripMenuItem51
       // 
-      resources.ApplyResources(this.toolStripMenuItem51, "toolStripMenuItem51");
       this.toolStripMenuItem51.Name = "toolStripMenuItem51";
+      resources.ApplyResources(this.toolStripMenuItem51, "toolStripMenuItem51");
       this.toolStripMenuItem51.Tag = "$8";
       // 
       // toolStripMenuItem50
       // 
-      resources.ApplyResources(this.toolStripMenuItem50, "toolStripMenuItem50");
       this.toolStripMenuItem50.Name = "toolStripMenuItem50";
+      resources.ApplyResources(this.toolStripMenuItem50, "toolStripMenuItem50");
       this.toolStripMenuItem50.Tag = "$9";
       // 
       // nameToolStripMenuItem
       // 
-      resources.ApplyResources(this.nameToolStripMenuItem, "nameToolStripMenuItem");
       this.nameToolStripMenuItem.Name = "nameToolStripMenuItem";
+      resources.ApplyResources(this.nameToolStripMenuItem, "nameToolStripMenuItem");
+      // 
+      // toolStripSeparator9
+      // 
+      this.toolStripSeparator9.Name = "toolStripSeparator9";
+      resources.ApplyResources(this.toolStripSeparator9, "toolStripSeparator9");
+      // 
+      // clearHistoryToolStripMenuItemFindF
+      // 
+      this.clearHistoryToolStripMenuItemFindF.Name = "clearHistoryToolStripMenuItemFindF";
+      resources.ApplyResources(this.clearHistoryToolStripMenuItemFindF, "clearHistoryToolStripMenuItemFindF");
+      // 
+      // toolStripSeparator10
+      // 
+      this.toolStripSeparator10.Name = "toolStripSeparator10";
+      resources.ApplyResources(this.toolStripSeparator10, "toolStripSeparator10");
+      // 
+      // clearHistoryToolStripMenuItemFindR
+      // 
+      this.clearHistoryToolStripMenuItemFindR.Name = "clearHistoryToolStripMenuItemFindR";
+      resources.ApplyResources(this.clearHistoryToolStripMenuItemFindR, "clearHistoryToolStripMenuItemFindR");
+      // 
+      // toolStripSeparator11
+      // 
+      this.toolStripSeparator11.Name = "toolStripSeparator11";
+      resources.ApplyResources(this.toolStripSeparator11, "toolStripSeparator11");
+      // 
+      // clearHistoryToolStripMenuItemReplace
+      // 
+      this.clearHistoryToolStripMenuItemReplace.Name = "clearHistoryToolStripMenuItemReplace";
+      resources.ApplyResources(this.clearHistoryToolStripMenuItemReplace, "clearHistoryToolStripMenuItemReplace");
       // 
       // FindReplaceDialog
       // 
@@ -1357,7 +1332,6 @@ namespace ScintillaNET_FindReplaceDialog
       this.Name = "FindReplaceDialog";
       this.ShowIcon = false;
       this.ShowInTaskbar = false;
-      this.toolTip1.SetToolTip(this, resources.GetString("$this.ToolTip"));
       this.Activated += new System.EventHandler(this.FindReplaceDialog_Activated);
       this.Deactivate += new System.EventHandler(this.FindReplaceDialog_Deactivate);
       this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FindReplaceDialog_FormClosing);
@@ -1381,8 +1355,11 @@ namespace ScintillaNET_FindReplaceDialog
       this.statusStrip.ResumeLayout(false);
       this.statusStrip.PerformLayout();
       this.mnuExtendedCharFindF.ResumeLayout(false);
+      this.mnuRecentFindF.ResumeLayout(false);
       this.mnuExtendedCharFindR.ResumeLayout(false);
       this.mnuExtendedCharReplace.ResumeLayout(false);
+      this.mnuRecentFindR.ResumeLayout(false);
+      this.mnuRecentReplace.ResumeLayout(false);
       this.mnuRegExCharFindF.ResumeLayout(false);
       this.mnuRegExCharFindR.ResumeLayout(false);
       this.mnuRegExCharReplace.ResumeLayout(false);
@@ -1544,5 +1521,11 @@ namespace ScintillaNET_FindReplaceDialog
 		private System.Windows.Forms.ToolStripMenuItem nameToolStripMenuItem;
         private System.Windows.Forms.Button btnFindPreviousR;
         private System.Windows.Forms.Button btnFindNextR;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator9;
+        private System.Windows.Forms.ToolStripMenuItem clearHistoryToolStripMenuItemFindF;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator10;
+        private System.Windows.Forms.ToolStripMenuItem clearHistoryToolStripMenuItemFindR;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator11;
+        private System.Windows.Forms.ToolStripMenuItem clearHistoryToolStripMenuItemReplace;
 	}
 }

--- a/ScintillaNet_FindReplaceDialog/FindReplace/FindReplaceDialog.cs
+++ b/ScintillaNet_FindReplaceDialog/FindReplace/FindReplaceDialog.cs
@@ -153,7 +153,7 @@ namespace ScintillaNET_FindReplaceDialog
                 }
                 catch (ArgumentException ex)
                 {
-                    lblStatus.Text = "Error in Regular Expression: " + ex.Message;
+                    lblStatus.Text = Properties.Resources.FindReplace_Status_ErrorInRegex + ex.Message;
                     return;
                 }
 
@@ -197,7 +197,7 @@ namespace ScintillaNET_FindReplaceDialog
 
             #endregion
 
-            lblStatus.Text = "Total found: " + foundCount.ToString();
+            lblStatus.Text = Properties.Resources.FindReplace_Status_TotalFound + foundCount.ToString();
         }
 
         private void btnFindNext_Click(object sender, EventArgs e)
@@ -230,7 +230,7 @@ namespace ScintillaNET_FindReplaceDialog
                 }
                 catch (ArgumentException ex)
                 {
-                    lblStatus.Text = "Error in Regular Expression: " + ex.Message;
+                    lblStatus.Text = Properties.Resources.FindReplace_Status_ErrorInRegex + ex.Message;
                     return;
                 }
 
@@ -276,7 +276,7 @@ namespace ScintillaNET_FindReplaceDialog
 
             #endregion
 
-            lblStatus.Text = "Total Replaced: " + foundCount.ToString();
+            lblStatus.Text = Properties.Resources.FindReplace_Status_TotalReplaced + foundCount.ToString();
         }
 
         private void btnReplaceNext_Click(object sender, EventArgs e)
@@ -299,22 +299,22 @@ namespace ScintillaNET_FindReplaceDialog
             }
             catch (ArgumentException ex)
             {
-                lblStatus.Text = "Error in Regular Expression: " + ex.Message;
+                lblStatus.Text = Properties.Resources.FindReplace_Status_ErrorInRegex + ex.Message;
                 return;
             }
 
             if (nextRange.cpMin == nextRange.cpMax)
             {
-                lblStatus.Text = "Match could not be found";
+                lblStatus.Text = Properties.Resources.FindReplace_Status_MatchNotFound;
             }
             else
             {
                 if (nextRange.cpMin > _scintilla.AnchorPosition)
                 {
                     if (chkSearchSelectionR.Checked)
-                        lblStatus.Text = "Search match wrapped to the beginning of the selection";
+                        lblStatus.Text = Properties.Resources.FindReplace_Status_MatchWrappedBeginningSelection;
                     else
-                        lblStatus.Text = "Search match wrapped to the beginning of the document";
+                        lblStatus.Text = Properties.Resources.FindReplace_Status_MatchWrappedBeginningDocument;
                 }
 
                 _scintilla.SetSel(nextRange.cpMin, nextRange.cpMax);
@@ -358,40 +358,49 @@ namespace ScintillaNET_FindReplaceDialog
 
         private void cmdRecentFindF_Click(object sender, EventArgs e)
         {
-            mnuRecentFindF.Items.Clear();
-            foreach (var item in MruFind)
+            while (mnuRecentFindF.Items.Count > 2)
             {
-                ToolStripItem newItem = mnuRecentFindF.Items.Add(item);
-                newItem.Tag = item;
+                mnuRecentFindF.Items.RemoveAt(0);
             }
-            mnuRecentFindF.Items.Add("-");
-            mnuRecentFindF.Items.Add("Clear History");
+            for (int i = 0; i < MruFind.Count; i++)
+            {
+                var item = MruFind[i];
+                ToolStripItem newItem = new ToolStripMenuItem(item);
+                newItem.Tag = item;
+                mnuRecentFindF.Items.Insert(i, newItem);
+            }
             mnuRecentFindF.Show(cmdRecentFindF.PointToScreen(cmdRecentFindF.ClientRectangle.Location));
         }
 
         private void cmdRecentFindR_Click(object sender, EventArgs e)
         {
-            mnuRecentFindR.Items.Clear();
-            foreach (var item in MruFind)
+            while (mnuRecentFindR.Items.Count > 2)
             {
-                ToolStripItem newItem = mnuRecentFindR.Items.Add(item);
-                newItem.Tag = item;
+                mnuRecentFindR.Items.RemoveAt(0);
             }
-            mnuRecentFindR.Items.Add("-");
-            mnuRecentFindR.Items.Add("Clear History");
+            for (var i = 0; i < MruFind.Count; i++)
+            {
+                var item = MruFind[i];
+                ToolStripItem newItem = new ToolStripMenuItem(item);
+                newItem.Tag = item;
+                mnuRecentFindR.Items.Insert(i, newItem);
+            }
             mnuRecentFindR.Show(cmdRecentFindR.PointToScreen(cmdRecentFindR.ClientRectangle.Location));
         }
 
         private void cmdRecentReplace_Click(object sender, EventArgs e)
         {
-            mnuRecentReplace.Items.Clear();
-            foreach (var item in MruReplace)
+            while (mnuRecentReplace.Items.Count > 2)
             {
-                ToolStripItem newItem = mnuRecentReplace.Items.Add(item);
-                newItem.Tag = item;
+                mnuRecentReplace.Items.RemoveAt(0);
             }
-            mnuRecentReplace.Items.Add("-");
-            mnuRecentReplace.Items.Add("Clear History");
+            for (var i = 0; i < MruReplace.Count; i++)
+            {
+                var item = MruFind[i];
+                ToolStripItem newItem = new ToolStripMenuItem(item);
+                newItem.Tag = item;
+                mnuRecentReplace.Items.Insert(i, newItem);
+            }
             mnuRecentReplace.Show(cmdRecentReplace.PointToScreen(cmdRecentReplace.ClientRectangle.Location));
         }
 
@@ -532,22 +541,22 @@ namespace ScintillaNET_FindReplaceDialog
             }
             catch (ArgumentException ex)
             {
-                lblStatus.Text = "Error in Regular Expression: " + ex.Message;
+                lblStatus.Text = Properties.Resources.FindReplace_Status_ErrorInRegex + ex.Message;
                 return;
             }
 
             if (foundRange.cpMin == foundRange.cpMax)
             {
-                lblStatus.Text = "Match could not be found";
+                lblStatus.Text = Properties.Resources.FindReplace_Status_MatchNotFound;
             }
             else
             {
                 if (foundRange.cpMin < Scintilla.AnchorPosition)
                 {
                     if (chkSearchSelectionF.Checked)
-                        lblStatus.Text = "Search match wrapped to the beginning of the selection";
+                        lblStatus.Text = Properties.Resources.FindReplace_Status_MatchWrappedBeginningSelection;
                     else
-                        lblStatus.Text = "Search match wrapped to the beginning of the document";
+                        lblStatus.Text = Properties.Resources.FindReplace_Status_MatchWrappedBeginningDocument;
                 }
 
                 Scintilla.SetSel(foundRange.cpMin, foundRange.cpMax);
@@ -571,22 +580,22 @@ namespace ScintillaNET_FindReplaceDialog
             }
             catch (ArgumentException ex)
             {
-                lblStatus.Text = "Error in Regular Expression: " + ex.Message;
+                lblStatus.Text = Properties.Resources.FindReplace_Status_ErrorInRegex + ex.Message;
                 return;
             }
 
             if (foundRange.cpMin == foundRange.cpMax)
             {
-                lblStatus.Text = "Match could not be found";
+                lblStatus.Text = Properties.Resources.FindReplace_Status_MatchNotFound;
             }
             else
             {
                 if (foundRange.cpMin > Scintilla.CurrentPosition)
                 {
                     if (chkSearchSelectionF.Checked)
-                        lblStatus.Text = "Search match wrapped to the _end of the selection";
+                        lblStatus.Text = Properties.Resources.FindReplace_Status_MatchWrappedEndSelection;
                     else
-                        lblStatus.Text = "Search match wrapped to the _end of the document";
+                        lblStatus.Text = Properties.Resources.FindReplace_Status_MatchWrappedEndDocument;
                 }
 
                 Scintilla.SetSel(foundRange.cpMin, foundRange.cpMax);
@@ -750,22 +759,22 @@ namespace ScintillaNET_FindReplaceDialog
             }
             catch (ArgumentException ex)
             {
-                lblStatus.Text = "Error in Regular Expression: " + ex.Message;
+                lblStatus.Text = Properties.Resources.FindReplace_Status_ErrorInRegex + ex.Message;
                 return;
             }
 
             if (nextRange.cpMin == nextRange.cpMax)
             {
-                lblStatus.Text = "Match could not be found";
+                lblStatus.Text = Properties.Resources.FindReplace_Status_MatchNotFound;
             }
             else
             {
                 if (nextRange.cpMin < Scintilla.AnchorPosition)
                 {
                     if (chkSearchSelectionR.Checked)
-                        lblStatus.Text = "Search match wrapped to the beginning of the selection";
+                        lblStatus.Text = Properties.Resources.FindReplace_Status_MatchWrappedBeginningSelection;
                     else
-                        lblStatus.Text = "Search match wrapped to the beginning of the document";
+                        lblStatus.Text = Properties.Resources.FindReplace_Status_MatchWrappedBeginningDocument;
                 }
 
                 Scintilla.SetSel(nextRange.cpMin, nextRange.cpMax);
@@ -1020,7 +1029,7 @@ namespace ScintillaNET_FindReplaceDialog
         private void mnuRecentFindF_ItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
             //Insert the string value held in the menu items Tag field (\t, \n, etc.)
-            if (e.ClickedItem.Text == "Clear History")
+            if (e.ClickedItem.Tag == null)
             {
                 MruFind.Clear();
             }
@@ -1033,7 +1042,7 @@ namespace ScintillaNET_FindReplaceDialog
         private void mnuRecentFindR_ItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
             //Insert the string value held in the menu items Tag field (\t, \n, etc.)
-            if (e.ClickedItem.Text == "Clear History")
+            if (e.ClickedItem.Tag == null)
             {
                 MruFind.Clear();
             }
@@ -1046,7 +1055,7 @@ namespace ScintillaNET_FindReplaceDialog
         private void mnuRecentReplace_ItemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
             //Insert the string value held in the menu items Tag field (\t, \n, etc.)
-            if (e.ClickedItem.Text == "Clear History")
+            if (e.ClickedItem.Tag == null)
             {
                 MruReplace.Clear();
             }

--- a/ScintillaNet_FindReplaceDialog/FindReplace/FindReplaceDialog.de.resx
+++ b/ScintillaNet_FindReplaceDialog/FindReplace/FindReplaceDialog.de.resx
@@ -118,6 +118,30 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="chkEcmaScriptF.Text" xml:space="preserve">
+    <value>ECMA Script</value>
+  </data>
+  <data name="chkEcmaScriptR.Text" xml:space="preserve">
+    <value>ECMA Script</value>
+  </data>
+  <data name="clearHistoryToolStripMenuItemFindF.Text" xml:space="preserve">
+    <value>Verlauf &amp;löschen</value>
+  </data>
+  <data name="clearHistoryToolStripMenuItemFindR.Text" xml:space="preserve">
+    <value>Verlauf &amp;löschen</value>
+  </data>
+  <data name="clearHistoryToolStripMenuItemReplace.Text" xml:space="preserve">
+    <value>Verlauf &amp;löschen</value>
+  </data>
+  <data name="cmdExtCharAndRegExFindF.Text" xml:space="preserve">
+    <value>&gt;</value>
+  </data>
+  <data name="cmdExtCharAndRegExFindR.Text" xml:space="preserve">
+    <value>&gt;</value>
+  </data>
+  <data name="cmdExtCharAndRegExReplace.Text" xml:space="preserve">
+    <value>&gt;</value>
+  </data>
   <data name="cmdRecentFindF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -128,11 +152,11 @@
   <data name="cmdRecentFindF.ToolTip" xml:space="preserve">
     <value>Eine Liste der letzten Suchen anzeigen</value>
   </data>
+  <data name="statusStrip.Text" xml:space="preserve">
+    <value>xxx</value>
+  </data>
   <data name="txtFindF.Size" type="System.Drawing.Size, System.Drawing">
     <value>428, 21</value>
-  </data>
-  <data name="txtFindF.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="cmdExtCharAndRegExFindF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -152,17 +176,11 @@
   <data name="rdoExtendedF.Text" xml:space="preserve">
     <value>Erweitert (\n, \r, \t, \0)</value>
   </data>
-  <data name="rdoExtendedF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnClear.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="btnClear.Text" xml:space="preserve">
     <value>&amp;Löschen</value>
-  </data>
-  <data name="btnClear.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="btnFindAll.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -170,17 +188,11 @@
   <data name="btnFindAll.Text" xml:space="preserve">
     <value>&amp;Alle suchen</value>
   </data>
-  <data name="btnFindAll.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkHighlightMatches.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="chkHighlightMatches.Text" xml:space="preserve">
     <value>Treffer &amp;markieren</value>
-  </data>
-  <data name="chkHighlightMatches.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkMarkLine.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -191,14 +203,8 @@
   <data name="chkMarkLine.Text" xml:space="preserve">
     <value>&amp;Zeile markieren</value>
   </data>
-  <data name="chkMarkLine.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="grpFindAll.Text" xml:space="preserve">
     <value>Alle suchen</value>
-  </data>
-  <data name="grpFindAll.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkSearchSelectionF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -209,9 +215,6 @@
   <data name="chkSearchSelectionF.Text" xml:space="preserve">
     <value>In Auswahl suchen</value>
   </data>
-  <data name="chkSearchSelectionF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkWrapF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -220,9 +223,6 @@
   </data>
   <data name="chkWrapF.Text" xml:space="preserve">
     <value>Am Ende von &amp;vorne beginnen</value>
-  </data>
-  <data name="chkWrapF.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="btnFindPreviousF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -233,9 +233,6 @@
   <data name="btnFindPreviousF.Text" xml:space="preserve">
     <value>&amp;Rückwärts suchen</value>
   </data>
-  <data name="btnFindPreviousF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnFindNextF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -244,9 +241,6 @@
   </data>
   <data name="btnFindNextF.Text" xml:space="preserve">
     <value>&amp;Weitersuchen</value>
-  </data>
-  <data name="btnFindNextF.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkWordStartF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -257,9 +251,6 @@
   <data name="chkWordStartF.Text" xml:space="preserve">
     <value>W&amp;ortanfang</value>
   </data>
-  <data name="chkWordStartF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkWholeWordF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -268,9 +259,6 @@
   </data>
   <data name="chkWholeWordF.Text" xml:space="preserve">
     <value>Ganzes Wor&amp;t</value>
-  </data>
-  <data name="chkWholeWordF.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkMatchCaseF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -281,14 +269,8 @@
   <data name="chkMatchCaseF.Text" xml:space="preserve">
     <value>Groß-/Kleinschreibung &amp;beachten</value>
   </data>
-  <data name="chkMatchCaseF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="pnlStandardOptionsF.Size" type="System.Drawing.Size, System.Drawing">
     <value>522, 57</value>
-  </data>
-  <data name="pnlStandardOptionsF.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkSinglelineF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -299,9 +281,6 @@
   <data name="chkSinglelineF.Text" xml:space="preserve">
     <value>Einzeilig</value>
   </data>
-  <data name="chkSinglelineF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkRightToLeftF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -310,9 +289,6 @@
   </data>
   <data name="chkRightToLeftF.Text" xml:space="preserve">
     <value>Rechts nach links</value>
-  </data>
-  <data name="chkRightToLeftF.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkMultilineF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -323,9 +299,6 @@
   <data name="chkMultilineF.Text" xml:space="preserve">
     <value>Mehrzeilig</value>
   </data>
-  <data name="chkMultilineF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkIgnorePatternWhitespaceF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -334,9 +307,6 @@
   </data>
   <data name="chkIgnorePatternWhitespaceF.Text" xml:space="preserve">
     <value>Leerraum i&amp;gnorieren</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceF.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkIgnoreCaseF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -347,9 +317,6 @@
   <data name="chkIgnoreCaseF.Text" xml:space="preserve">
     <value>Groß/Klein &amp;ignorieren</value>
   </data>
-  <data name="chkIgnoreCaseF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkExplicitCaptureF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -359,14 +326,8 @@
   <data name="chkExplicitCaptureF.Text" xml:space="preserve">
     <value>E&amp;xplizite Erfassung</value>
   </data>
-  <data name="chkExplicitCaptureF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkEcmaScriptF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
-  </data>
-  <data name="chkEcmaScriptF.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkCultureInvariantF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -377,9 +338,6 @@
   <data name="chkCultureInvariantF.Text" xml:space="preserve">
     <value>Invariante K&amp;ultur</value>
   </data>
-  <data name="chkCultureInvariantF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkCompiledF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -389,23 +347,14 @@
   <data name="chkCompiledF.Text" xml:space="preserve">
     <value>&amp;Kompiliert</value>
   </data>
-  <data name="chkCompiledF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="pnlRegexpOptionsF.Size" type="System.Drawing.Size, System.Drawing">
     <value>522, 57</value>
-  </data>
-  <data name="pnlRegexpOptionsF.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="grpOptionsF.Size" type="System.Drawing.Size, System.Drawing">
     <value>528, 77</value>
   </data>
   <data name="grpOptionsF.Text" xml:space="preserve">
     <value>Optionen</value>
-  </data>
-  <data name="grpOptionsF.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="lblSearchTypeF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -416,9 +365,6 @@
   <data name="lblSearchTypeF.Text" xml:space="preserve">
     <value>Suchtyp</value>
   </data>
-  <data name="lblSearchTypeF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="rdoRegexF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -428,17 +374,11 @@
   <data name="rdoRegexF.Text" xml:space="preserve">
     <value>Regul&amp;ärer Ausdruck</value>
   </data>
-  <data name="rdoRegexF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="rdoStandardF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="rdoStandardF.Text" xml:space="preserve">
     <value>Stan&amp;dard</value>
-  </data>
-  <data name="rdoStandardF.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="lblFindF.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -449,41 +389,23 @@
   <data name="lblFindF.Text" xml:space="preserve">
     <value>&amp;Suchen</value>
   </data>
-  <data name="lblFindF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="tpgFind.Size" type="System.Drawing.Size, System.Drawing">
     <value>538, 244</value>
   </data>
   <data name="tpgFind.Text" xml:space="preserve">
     <value>Suchen</value>
   </data>
-  <data name="tpgFind.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnFindNextR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="btnFindNextR.Text" xml:space="preserve">
-    <value>Weitersuchen </value>
-  </data>
-  <data name="btnFindNextR.ToolTip" xml:space="preserve">
-    <value />
+    <value>Weitersuchen</value>
   </data>
   <data name="btnFindPreviousR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="btnFindPreviousR.Text" xml:space="preserve">
     <value>Rückwärts suchen</value>
-  </data>
-  <data name="btnFindPreviousR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="txtReplace.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="txtFindR.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="cmdExtCharAndRegExReplace.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -506,17 +428,11 @@
   <data name="rdoExtendedR.Text" xml:space="preserve">
     <value>Erweitert (\n, \r, \t, \0)</value>
   </data>
-  <data name="rdoExtendedR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnReplaceAll.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="btnReplaceAll.Text" xml:space="preserve">
     <value>&amp;Alle ersetzen</value>
-  </data>
-  <data name="btnReplaceAll.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="lblReplace.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -527,9 +443,6 @@
   <data name="lblReplace.Text" xml:space="preserve">
     <value>&amp;Ersetzen</value>
   </data>
-  <data name="lblReplace.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkSearchSelectionR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -538,9 +451,6 @@
   </data>
   <data name="chkSearchSelectionR.Text" xml:space="preserve">
     <value>In Auswahl suchen</value>
-  </data>
-  <data name="chkSearchSelectionR.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkWrapR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -551,26 +461,17 @@
   <data name="chkWrapR.Text" xml:space="preserve">
     <value>Am Ende von &amp;vorne beginnen</value>
   </data>
-  <data name="chkWrapR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnReplacePrevious.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="btnReplacePrevious.Text" xml:space="preserve">
     <value>&amp;Rückwärts ersetzen</value>
   </data>
-  <data name="btnReplacePrevious.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="btnReplaceNext.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="btnReplaceNext.Text" xml:space="preserve">
     <value>&amp;Weiter ersetzen</value>
-  </data>
-  <data name="btnReplaceNext.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkWordStartR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -581,9 +482,6 @@
   <data name="chkWordStartR.Text" xml:space="preserve">
     <value>W&amp;ortanfang</value>
   </data>
-  <data name="chkWordStartR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkWholeWordR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -592,9 +490,6 @@
   </data>
   <data name="chkWholeWordR.Text" xml:space="preserve">
     <value>Ganzes Wor&amp;t</value>
-  </data>
-  <data name="chkWholeWordR.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkMatchCaseR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -605,12 +500,6 @@
   <data name="chkMatchCaseR.Text" xml:space="preserve">
     <value>Groß-/Kleinschreibung &amp;beachten</value>
   </data>
-  <data name="chkMatchCaseR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="pnlStandardOptionsR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkSinglelineR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -619,9 +508,6 @@
   </data>
   <data name="chkSinglelineR.Text" xml:space="preserve">
     <value>Einzeilig</value>
-  </data>
-  <data name="chkSinglelineR.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkRightToLeftR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -632,9 +518,6 @@
   <data name="chkRightToLeftR.Text" xml:space="preserve">
     <value>Rechts nach links</value>
   </data>
-  <data name="chkRightToLeftR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkMultilineR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -643,9 +526,6 @@
   </data>
   <data name="chkMultilineR.Text" xml:space="preserve">
     <value>Mehrzeilig</value>
-  </data>
-  <data name="chkMultilineR.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkIgnorePatternWhitespaceR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -656,9 +536,6 @@
   <data name="chkIgnorePatternWhitespaceR.Text" xml:space="preserve">
     <value>Leerraum i&amp;gnorieren</value>
   </data>
-  <data name="chkIgnorePatternWhitespaceR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkIgnoreCaseR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -667,9 +544,6 @@
   </data>
   <data name="chkIgnoreCaseR.Text" xml:space="preserve">
     <value>Groß/Klein &amp;ignorieren</value>
-  </data>
-  <data name="chkIgnoreCaseR.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkExplicitCaptureR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -680,14 +554,8 @@
   <data name="chkExplicitCaptureR.Text" xml:space="preserve">
     <value>E&amp;xplizite Erfassung</value>
   </data>
-  <data name="chkExplicitCaptureR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkEcmaScriptR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
-  </data>
-  <data name="chkEcmaScriptR.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="chkCultureInvariantR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -698,9 +566,6 @@
   <data name="chkCultureInvariantR.Text" xml:space="preserve">
     <value>Invariante K&amp;ultur</value>
   </data>
-  <data name="chkCultureInvariantR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="chkCompiledR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -710,17 +575,8 @@
   <data name="chkCompiledR.Text" xml:space="preserve">
     <value>&amp;Kompiliert</value>
   </data>
-  <data name="chkCompiledR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="pnlRegexpOptionsR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="grdOptionsR.Text" xml:space="preserve">
     <value>Optionen</value>
-  </data>
-  <data name="grdOptionsR.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="lblSearchTypeR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -731,9 +587,6 @@
   <data name="lblSearchTypeR.Text" xml:space="preserve">
     <value>Suchtyp</value>
   </data>
-  <data name="lblSearchTypeR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="rdoRegexR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -743,17 +596,11 @@
   <data name="rdoRegexR.Text" xml:space="preserve">
     <value>Regul&amp;ärer Ausdruck</value>
   </data>
-  <data name="rdoRegexR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="rdoStandardR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="rdoStandardR.Text" xml:space="preserve">
     <value>Stan&amp;dard</value>
-  </data>
-  <data name="rdoStandardR.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="lblFindR.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -763,9 +610,6 @@
   </data>
   <data name="lblFindR.Text" xml:space="preserve">
     <value>&amp;Suchen</value>
-  </data>
-  <data name="lblFindR.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="cmdRecentReplace.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -782,20 +626,11 @@
   <data name="tpgReplace.Text" xml:space="preserve">
     <value>Ersetzen</value>
   </data>
-  <data name="tpgReplace.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="tabAll.Size" type="System.Drawing.Size, System.Drawing">
     <value>546, 270</value>
   </data>
-  <data name="tabAll.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="statusStrip.Size" type="System.Drawing.Size, System.Drawing">
     <value>546, 22</value>
-  </data>
-  <data name="statusStrip.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="toolStripMenuItem13.Size" type="System.Drawing.Size, System.Drawing">
     <value>208, 22</value>
@@ -830,12 +665,6 @@
   <data name="mnuExtendedCharFindF.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 114</value>
   </data>
-  <data name="mnuExtendedCharFindF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="mnuRecentFindF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="toolStripMenuItem14.Size" type="System.Drawing.Size, System.Drawing">
     <value>208, 22</value>
   </data>
@@ -869,9 +698,6 @@
   <data name="mnuExtendedCharFindR.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 114</value>
   </data>
-  <data name="mnuExtendedCharFindR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="toolStripMenuItem15.Size" type="System.Drawing.Size, System.Drawing">
     <value>208, 22</value>
   </data>
@@ -904,15 +730,6 @@
   </data>
   <data name="mnuExtendedCharReplace.Size" type="System.Drawing.Size, System.Drawing">
     <value>209, 114</value>
-  </data>
-  <data name="mnuExtendedCharReplace.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="mnuRecentFindR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="mnuRecentReplace.ToolTip" xml:space="preserve">
-    <value />
   </data>
   <data name="toolStripMenuItem9.Size" type="System.Drawing.Size, System.Drawing">
     <value>304, 22</value>
@@ -1037,9 +854,6 @@
   <data name="mnuRegExCharFindF.Size" type="System.Drawing.Size, System.Drawing">
     <value>305, 424</value>
   </data>
-  <data name="mnuRegExCharFindF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="toolStripMenuItem30.Size" type="System.Drawing.Size, System.Drawing">
     <value>304, 22</value>
   </data>
@@ -1163,9 +977,6 @@
   <data name="mnuRegExCharFindR.Size" type="System.Drawing.Size, System.Drawing">
     <value>305, 424</value>
   </data>
-  <data name="mnuRegExCharFindR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="toolStripMenuItem48.Size" type="System.Drawing.Size, System.Drawing">
     <value>213, 22</value>
   </data>
@@ -1235,9 +1046,6 @@
   <data name="mnuRegExCharReplace.Size" type="System.Drawing.Size, System.Drawing">
     <value>214, 246</value>
   </data>
-  <data name="mnuRegExCharReplace.ToolTip" xml:space="preserve">
-    <value />
-  </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>546, 292</value>
   </data>
@@ -1247,7 +1055,4 @@
   <data name="$this.Text" xml:space="preserve">
     <value>Suchen und Ersetzen</value>
   </data>
-  <data name="$this.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-</root>
+</root>

--- a/ScintillaNet_FindReplaceDialog/FindReplace/FindReplaceDialog.resx
+++ b/ScintillaNet_FindReplaceDialog/FindReplace/FindReplaceDialog.resx
@@ -117,3079 +117,2920 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="toolStripMenuItem19.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;grpOptionsF.Name" xml:space="preserve">
-    <value>grpOptionsF</value>
-  </data>
-  <data name="chkExplicitCaptureF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 17</value>
-  </data>
-  <data name="&gt;&gt;chkWrapF.Name" xml:space="preserve">
-    <value>chkWrapF</value>
-  </data>
-  <data name="&gt;&gt;rCarriageToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkWrapF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem57.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlRegexpOptionsF.Parent" xml:space="preserve">
-    <value>grpOptionsF</value>
-  </data>
-  <data name="toolStripMenuItem41.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="btnFindPreviousR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 23</value>
-  </data>
-  <data name="toolStripMenuItem13.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="chkIgnoreCaseR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnClear.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 23</value>
-  </data>
-  <data name="&gt;&gt;chkMatchCaseF.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>257, 6</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="cmdRecentFindF.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
   <data name="cmdRecentFindF.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>None</value>
   </data>
-  <data name="toolStripMenuItem35.Text" xml:space="preserve">
-    <value>\r\n Windows New Line</value>
-  </data>
-  <data name="chkWholeWordR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="cmdExtCharAndRegExReplace.Text" xml:space="preserve">
-    <value>&gt;</value>
-  </data>
-  <data name="&gt;&gt;btnFindNextR.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkCultureInvariantR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem3.Text" xml:space="preserve">
-    <value>\t Tab</value>
-  </data>
-  <data name="tpgFind.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem39.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cmdRecentReplace.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="statusStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>488, 22</value>
-  </data>
-  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem31.Name" xml:space="preserve">
-    <value>toolStripMenuItem31</value>
-  </data>
-  <data name="&gt;&gt;mnuRecentReplace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem22.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem49.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFindR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem41.Text" xml:space="preserve">
-    <value>+ One or More Repetitions</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem37.Name" xml:space="preserve">
-    <value>toolStripMenuItem37</value>
-  </data>
-  <data name="pnlRegexpOptionsR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="chkMatchCaseR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 3</value>
-  </data>
-  <data name="toolStripMenuItem36.Text" xml:space="preserve">
-    <value>\n Line Feed</value>
-  </data>
-  <data name="cmdRecentReplace.ToolTip" xml:space="preserve">
-    <value>Show a list of recent search strings</value>
-  </data>
-  <data name="toolStripMenuItem4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem41.Name" xml:space="preserve">
-    <value>toolStripMenuItem41</value>
-  </data>
-  <data name="nNewLineToolStripMenuItem.Text" xml:space="preserve">
-    <value>\n Line Feed</value>
-  </data>
-  <data name="cmdExtCharAndRegExReplace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 23</value>
-  </data>
-  <data name="&gt;&gt;cmdExtCharAndRegExFindR.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="cmdExtCharAndRegExReplace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>453, 27</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem18.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cmdRecentFindF.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;btnFindAll.Parent" xml:space="preserve">
-    <value>grpFindAll</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem12.Name" xml:space="preserve">
-    <value>toolStripMenuItem12</value>
-  </data>
-  <data name="chkMatchCaseF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 3</value>
-  </data>
-  <data name="&gt;&gt;tpgFind.Parent" xml:space="preserve">
-    <value>tabAll</value>
-  </data>
-  <data name="chkCultureInvariantF.Text" xml:space="preserve">
-    <value>C&amp;ulture Invariant</value>
-  </data>
-  <data name="toolStripMenuItem43.Text" xml:space="preserve">
-    <value>? As Few as Possible (i.e. *?, +? or ??)</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem9.Name" xml:space="preserve">
-    <value>toolStripMenuItem9</value>
-  </data>
-  <data name="chkMultilineR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;chkRightToLeftR.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;chkMarkLine.Parent" xml:space="preserve">
-    <value>grpFindAll</value>
-  </data>
-  <data name="btnFindNextF.Text" xml:space="preserve">
-    <value>Find &amp;Next</value>
-  </data>
-  <data name="chkIgnoreCaseF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="toolStripMenuItem34.Text" xml:space="preserve">
-    <value>[a-zA-Z] Specified Set ([^a...] Not in Set)</value>
-  </data>
-  <data name="&gt;&gt;pnlRegexpOptionsF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkCultureInvariantF.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="cmdRecentFindF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>430, 5</value>
   </data>
   <data name="cmdRecentFindF.Size" type="System.Drawing.Size, System.Drawing">
     <value>23, 23</value>
   </data>
-  <data name="chkCultureInvariantR.ToolTip" xml:space="preserve">
-    <value />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="cmdRecentFindF.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem25.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 56</value>
+  </metadata>
+  <data name="cmdRecentFindF.ToolTip" xml:space="preserve">
+    <value>Show a list of recent search strings</value>
   </data>
-  <data name="mnuRegExCharFindF.ToolTip" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;cmdRecentFindF.Name" xml:space="preserve">
+    <value>cmdRecentFindF</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem51.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;cmdRecentFindF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem54.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;cmdRecentFindF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
   </data>
-  <data name="lblSearchTypeF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;cmdRecentFindF.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="cmdRecentReplace.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
+  <data name="txtFindF.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem24.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="txtFindF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>59, 6</value>
   </data>
-  <data name="chkIgnoreCaseR.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+  <data name="txtFindF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>370, 21</value>
   </data>
-  <data name="chkMatchCaseR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="txtFindF.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
   </data>
-  <data name="&gt;&gt;chkCultureInvariantF.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsF</value>
+  <data name="&gt;&gt;txtFindF.Name" xml:space="preserve">
+    <value>txtFindF</value>
   </data>
-  <data name="&gt;&gt;chkIgnoreCaseR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;txtFindF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem6.Name" xml:space="preserve">
-    <value>toolStripMenuItem6</value>
+  <data name="&gt;&gt;txtFindF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
   </data>
-  <data name="mnuExtendedCharFindF.ToolTip" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;txtFindF.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;chkSearchSelectionR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="cmdExtCharAndRegExFindF.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
-  <data name="mnuRegExCharReplace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 246</value>
+  <data name="cmdExtCharAndRegExFindF.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
-  <data name="grdOptionsR.ToolTip" xml:space="preserve">
-    <value />
+  <data name="cmdExtCharAndRegExFindF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>453, 5</value>
   </data>
-  <data name="toolStripMenuItem2.Text" xml:space="preserve">
-    <value>\r Carriage Return</value>
+  <data name="cmdExtCharAndRegExFindF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="cmdExtCharAndRegExFindF.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="cmdExtCharAndRegExFindF.Text" xml:space="preserve">
+    <value>&gt;</value>
+  </data>
+  <data name="cmdExtCharAndRegExFindF.ToolTip" xml:space="preserve">
+    <value>Show a list of extended characters</value>
   </data>
   <data name="&gt;&gt;cmdExtCharAndRegExFindF.Name" xml:space="preserve">
     <value>cmdExtCharAndRegExFindF</value>
   </data>
-  <data name="toolStripMenuItem25.Text" xml:space="preserve">
-    <value>\r\n Windows New Line</value>
+  <data name="&gt;&gt;cmdExtCharAndRegExFindF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="grpOptionsF.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;cmdExtCharAndRegExFindF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;cmdExtCharAndRegExFindF.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="rdoExtendedF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoExtendedF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>102, 71</value>
+  </data>
+  <data name="rdoExtendedF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>139, 17</value>
+  </data>
+  <data name="rdoExtendedF.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="rdoExtendedF.Text" xml:space="preserve">
+    <value>E&amp;xtended (\n, \r, \t, \0)</value>
+  </data>
+  <data name="&gt;&gt;rdoExtendedF.Name" xml:space="preserve">
+    <value>rdoExtendedF</value>
+  </data>
+  <data name="&gt;&gt;rdoExtendedF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoExtendedF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;rdoExtendedF.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="btnClear.Location" type="System.Drawing.Point, System.Drawing">
+    <value>116, 37</value>
+  </data>
+  <data name="btnClear.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 23</value>
+  </data>
+  <data name="btnClear.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="btnClear.Text" xml:space="preserve">
+    <value>C&amp;lear</value>
+  </data>
+  <data name="&gt;&gt;btnClear.Name" xml:space="preserve">
+    <value>btnClear</value>
+  </data>
+  <data name="&gt;&gt;btnClear.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnClear.Parent" xml:space="preserve">
+    <value>grpFindAll</value>
+  </data>
+  <data name="&gt;&gt;btnClear.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnFindAll.Location" type="System.Drawing.Point, System.Drawing">
+    <value>116, 13</value>
+  </data>
+  <data name="btnFindAll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 23</value>
+  </data>
+  <data name="btnFindAll.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="btnFindAll.Text" xml:space="preserve">
+    <value>Find &amp;All</value>
+  </data>
+  <data name="&gt;&gt;btnFindAll.Name" xml:space="preserve">
+    <value>btnFindAll</value>
+  </data>
+  <data name="&gt;&gt;btnFindAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnFindAll.Parent" xml:space="preserve">
+    <value>grpFindAll</value>
+  </data>
+  <data name="&gt;&gt;btnFindAll.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="chkHighlightMatches.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkHighlightMatches.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 37</value>
+  </data>
+  <data name="chkHighlightMatches.Size" type="System.Drawing.Size, System.Drawing">
+    <value>110, 17</value>
+  </data>
+  <data name="chkHighlightMatches.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="chkHighlightMatches.Text" xml:space="preserve">
+    <value>&amp;Highlight Matches</value>
+  </data>
+  <data name="&gt;&gt;chkHighlightMatches.Name" xml:space="preserve">
+    <value>chkHighlightMatches</value>
+  </data>
+  <data name="&gt;&gt;chkHighlightMatches.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkHighlightMatches.Parent" xml:space="preserve">
+    <value>grpFindAll</value>
+  </data>
+  <data name="&gt;&gt;chkHighlightMatches.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="chkMarkLine.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkMarkLine.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 20</value>
+  </data>
+  <data name="chkMarkLine.Size" type="System.Drawing.Size, System.Drawing">
+    <value>71, 17</value>
+  </data>
+  <data name="chkMarkLine.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="chkMarkLine.Text" xml:space="preserve">
+    <value>&amp;Mark Line</value>
+  </data>
+  <data name="&gt;&gt;chkMarkLine.Name" xml:space="preserve">
+    <value>chkMarkLine</value>
+  </data>
+  <data name="&gt;&gt;chkMarkLine.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkMarkLine.Parent" xml:space="preserve">
+    <value>grpFindAll</value>
+  </data>
+  <data name="&gt;&gt;chkMarkLine.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="grpFindAll.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 176</value>
+  </data>
+  <data name="grpFindAll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>209, 65</value>
+  </data>
+  <data name="grpFindAll.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="grpFindAll.Text" xml:space="preserve">
+    <value>Find All</value>
+  </data>
+  <data name="&gt;&gt;grpFindAll.Name" xml:space="preserve">
+    <value>grpFindAll</value>
+  </data>
+  <data name="&gt;&gt;grpFindAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpFindAll.Parent" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;grpFindAll.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="chkSearchSelectionF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkSearchSelectionF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>375, 71</value>
+  </data>
+  <data name="chkSearchSelectionF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>105, 17</value>
+  </data>
+  <data name="chkSearchSelectionF.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="chkSearchSelectionF.Text" xml:space="preserve">
+    <value>Search Selection</value>
+  </data>
+  <data name="&gt;&gt;chkSearchSelectionF.Name" xml:space="preserve">
+    <value>chkSearchSelectionF</value>
+  </data>
+  <data name="&gt;&gt;chkSearchSelectionF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkSearchSelectionF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;chkSearchSelectionF.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="chkWrapF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkWrapF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>375, 52</value>
+  </data>
+  <data name="chkWrapF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>52, 17</value>
+  </data>
+  <data name="chkWrapF.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="chkWrapF.Text" xml:space="preserve">
+    <value>&amp;Wrap</value>
+  </data>
+  <data name="&gt;&gt;chkWrapF.Name" xml:space="preserve">
+    <value>chkWrapF</value>
+  </data>
+  <data name="&gt;&gt;chkWrapF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkWrapF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;chkWrapF.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="btnFindPreviousF.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnFindPreviousF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>364, 188</value>
+  </data>
+  <data name="btnFindPreviousF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 23</value>
+  </data>
+  <data name="btnFindPreviousF.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="btnFindPreviousF.Text" xml:space="preserve">
+    <value>Find &amp;Previous</value>
+  </data>
+  <data name="&gt;&gt;btnFindPreviousF.Name" xml:space="preserve">
+    <value>btnFindPreviousF</value>
+  </data>
+  <data name="&gt;&gt;btnFindPreviousF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnFindPreviousF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;btnFindPreviousF.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
-  <data name="&gt;&gt;chkMatchCaseR.Type" xml:space="preserve">
+  <data name="btnFindNextF.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnFindNextF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>364, 212</value>
+  </data>
+  <data name="btnFindNextF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 23</value>
+  </data>
+  <data name="btnFindNextF.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="btnFindNextF.Text" xml:space="preserve">
+    <value>Find &amp;Next</value>
+  </data>
+  <data name="&gt;&gt;btnFindNextF.Name" xml:space="preserve">
+    <value>btnFindNextF</value>
+  </data>
+  <data name="&gt;&gt;btnFindNextF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnFindNextF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;btnFindNextF.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="grpOptionsF.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="chkWordStartF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkWordStartF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 37</value>
+  </data>
+  <data name="chkWordStartF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 17</value>
+  </data>
+  <data name="chkWordStartF.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="chkWordStartF.Text" xml:space="preserve">
+    <value>W&amp;ord Start</value>
+  </data>
+  <data name="&gt;&gt;chkWordStartF.Name" xml:space="preserve">
+    <value>chkWordStartF</value>
+  </data>
+  <data name="&gt;&gt;chkWordStartF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkWordStartF.Parent" xml:space="preserve">
+    <value>pnlStandardOptionsF</value>
+  </data>
+  <data name="&gt;&gt;chkWordStartF.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="chkWholeWordF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkWholeWordF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 20</value>
+  </data>
+  <data name="chkWholeWordF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>85, 17</value>
+  </data>
+  <data name="chkWholeWordF.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="chkWholeWordF.Text" xml:space="preserve">
+    <value>Whole Wor&amp;d</value>
+  </data>
+  <data name="&gt;&gt;chkWholeWordF.Name" xml:space="preserve">
+    <value>chkWholeWordF</value>
+  </data>
+  <data name="&gt;&gt;chkWholeWordF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkWholeWordF.Parent" xml:space="preserve">
+    <value>pnlStandardOptionsF</value>
+  </data>
+  <data name="&gt;&gt;chkWholeWordF.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="chkMatchCaseF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkMatchCaseF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 3</value>
+  </data>
+  <data name="chkMatchCaseF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>82, 17</value>
+  </data>
+  <data name="chkMatchCaseF.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="chkMatchCaseF.Text" xml:space="preserve">
+    <value>Match &amp;Case</value>
+  </data>
+  <data name="&gt;&gt;chkMatchCaseF.Name" xml:space="preserve">
+    <value>chkMatchCaseF</value>
+  </data>
+  <data name="&gt;&gt;chkMatchCaseF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkMatchCaseF.Parent" xml:space="preserve">
+    <value>pnlStandardOptionsF</value>
+  </data>
+  <data name="&gt;&gt;chkMatchCaseF.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="pnlStandardOptionsF.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pnlStandardOptionsF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 17</value>
+  </data>
+  <data name="pnlStandardOptionsF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>464, 57</value>
+  </data>
+  <data name="pnlStandardOptionsF.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;pnlStandardOptionsF.Name" xml:space="preserve">
+    <value>pnlStandardOptionsF</value>
+  </data>
+  <data name="&gt;&gt;pnlStandardOptionsF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pnlStandardOptionsF.Parent" xml:space="preserve">
+    <value>grpOptionsF</value>
+  </data>
+  <data name="&gt;&gt;pnlStandardOptionsF.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="chkSinglelineF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkSinglelineF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>279, 37</value>
+  </data>
+  <data name="chkSinglelineF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 17</value>
+  </data>
+  <data name="chkSinglelineF.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="chkSinglelineF.Text" xml:space="preserve">
+    <value>Singleline</value>
+  </data>
+  <data name="&gt;&gt;chkSinglelineF.Name" xml:space="preserve">
+    <value>chkSinglelineF</value>
+  </data>
+  <data name="&gt;&gt;chkSinglelineF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkSinglelineF.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsF</value>
+  </data>
+  <data name="&gt;&gt;chkSinglelineF.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="chkRightToLeftF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkRightToLeftF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>279, 20</value>
+  </data>
+  <data name="chkRightToLeftF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 17</value>
+  </data>
+  <data name="chkRightToLeftF.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="chkRightToLeftF.Text" xml:space="preserve">
+    <value>Right To Left</value>
+  </data>
+  <data name="&gt;&gt;chkRightToLeftF.Name" xml:space="preserve">
+    <value>chkRightToLeftF</value>
+  </data>
+  <data name="&gt;&gt;chkRightToLeftF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkRightToLeftF.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsF</value>
+  </data>
+  <data name="&gt;&gt;chkRightToLeftF.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="chkMultilineF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkMultilineF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>279, 3</value>
+  </data>
+  <data name="chkMultilineF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 17</value>
+  </data>
+  <data name="chkMultilineF.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="chkMultilineF.Text" xml:space="preserve">
+    <value>Multiline</value>
+  </data>
+  <data name="&gt;&gt;chkMultilineF.Name" xml:space="preserve">
+    <value>chkMultilineF</value>
+  </data>
+  <data name="&gt;&gt;chkMultilineF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkMultilineF.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsF</value>
+  </data>
+  <data name="&gt;&gt;chkMultilineF.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="chkIgnorePatternWhitespaceF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkIgnorePatternWhitespaceF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>113, 37</value>
+  </data>
+  <data name="chkIgnorePatternWhitespaceF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>156, 17</value>
+  </data>
+  <data name="chkIgnorePatternWhitespaceF.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="chkIgnorePatternWhitespaceF.Text" xml:space="preserve">
+    <value>I&amp;gnore Pattern Whitespace</value>
+  </data>
+  <data name="&gt;&gt;chkIgnorePatternWhitespaceF.Name" xml:space="preserve">
+    <value>chkIgnorePatternWhitespaceF</value>
+  </data>
+  <data name="&gt;&gt;chkIgnorePatternWhitespaceF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkIgnorePatternWhitespaceF.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsF</value>
+  </data>
+  <data name="&gt;&gt;chkIgnorePatternWhitespaceF.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="chkIgnoreCaseF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkIgnoreCaseF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>113, 20</value>
+  </data>
+  <data name="chkIgnoreCaseF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>85, 17</value>
+  </data>
+  <data name="chkIgnoreCaseF.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="chkIgnoreCaseF.Text" xml:space="preserve">
+    <value>&amp;Ignore Case</value>
+  </data>
+  <data name="&gt;&gt;chkIgnoreCaseF.Name" xml:space="preserve">
+    <value>chkIgnoreCaseF</value>
+  </data>
+  <data name="&gt;&gt;chkIgnoreCaseF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkIgnoreCaseF.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsF</value>
+  </data>
+  <data name="&gt;&gt;chkIgnoreCaseF.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="chkExplicitCaptureF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkExplicitCaptureF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>113, 3</value>
+  </data>
+  <data name="chkExplicitCaptureF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 17</value>
+  </data>
+  <data name="chkExplicitCaptureF.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="chkExplicitCaptureF.Text" xml:space="preserve">
+    <value>E&amp;xplicit Capture</value>
+  </data>
+  <data name="&gt;&gt;chkExplicitCaptureF.Name" xml:space="preserve">
+    <value>chkExplicitCaptureF</value>
+  </data>
+  <data name="&gt;&gt;chkExplicitCaptureF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkExplicitCaptureF.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsF</value>
+  </data>
+  <data name="&gt;&gt;chkExplicitCaptureF.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="chkEcmaScriptF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkEcmaScriptF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 37</value>
+  </data>
+  <data name="chkEcmaScriptF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>84, 17</value>
+  </data>
+  <data name="chkEcmaScriptF.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="chkEcmaScriptF.Text" xml:space="preserve">
+    <value>ECMA Script</value>
+  </data>
+  <data name="&gt;&gt;chkEcmaScriptF.Name" xml:space="preserve">
+    <value>chkEcmaScriptF</value>
+  </data>
+  <data name="&gt;&gt;chkEcmaScriptF.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;chkEcmaScriptF.Parent" xml:space="preserve">
     <value>pnlRegexpOptionsF</value>
   </data>
-  <data name="chkSinglelineR.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+  <data name="&gt;&gt;chkEcmaScriptF.ZOrder" xml:space="preserve">
+    <value>6</value>
   </data>
-  <data name="btnFindNextR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>251, 212</value>
-  </data>
-  <data name="lblSearchTypeF.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem46.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkIgnoreCaseR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>113, 20</value>
-  </data>
-  <data name="&gt;&gt;chkIgnorePatternWhitespaceR.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsR</value>
-  </data>
-  <data name="toolStripMenuItem52.Text" xml:space="preserve">
-    <value>$7 Numbered Group #7</value>
-  </data>
-  <data name="chkMatchCaseR.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnFindPreviousR.Name" xml:space="preserve">
-    <value>btnFindPreviousR</value>
-  </data>
-  <data name="chkMultilineF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 3</value>
-  </data>
-  <data name="chkMatchCaseF.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;btnClear.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="chkCompiledF.AutoSize" type="System.Boolean, mscorlib">
+  <data name="chkCultureInvariantF.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="toolStripMenuItem57.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="grpFindAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 176</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem53.Name" xml:space="preserve">
-    <value>toolStripMenuItem53</value>
-  </data>
-  <data name="&gt;&gt;btnClear.Parent" xml:space="preserve">
-    <value>grpFindAll</value>
-  </data>
-  <data name="&gt;&gt;nullCharactorToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem28.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem1.Text" xml:space="preserve">
-    <value>\n Line Feed</value>
-  </data>
-  <data name="lblFindR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 10</value>
-  </data>
-  <data name="&gt;&gt;rdoStandardR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="&gt;&gt;chkIgnoreCaseF.Name" xml:space="preserve">
-    <value>chkIgnoreCaseF</value>
-  </data>
-  <data name="&gt;&gt;txtReplace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkEcmaScriptF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnReplacePrevious.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;mnuRecentFindF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabAll.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="btnReplaceNext.Text" xml:space="preserve">
-    <value>Replace &amp;Next</value>
-  </data>
-  <data name="cmdRecentReplace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 23</value>
-  </data>
-  <data name="toolStripMenuItem30.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;chkSinglelineR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="rdoRegexF.Text" xml:space="preserve">
-    <value>Regular &amp;Expression</value>
-  </data>
-  <data name="&gt;&gt;btnFindNextF.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="cmdRecentFindR.ToolTip" xml:space="preserve">
-    <value>Show a list of recent search strings</value>
-  </data>
-  <data name="&gt;&gt;btnFindPreviousR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkCultureInvariantR.Text" xml:space="preserve">
-    <value>C&amp;ulture Invariant</value>
-  </data>
-  <data name="btnFindPreviousF.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;chkWordStartR.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkIgnorePatternWhitespaceR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFindF.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;grpFindAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkSinglelineF.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;tpgFind.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="toolStripMenuItem11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="chkWrapF.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="toolStripSeparator3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>257, 6</value>
-  </data>
-  <data name="chkSinglelineR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 17</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem30.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="btnClear.Text" xml:space="preserve">
-    <value>C&amp;lear</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem52.Name" xml:space="preserve">
-    <value>toolStripMenuItem52</value>
-  </data>
-  <data name="&gt;&gt;txtFindR.Name" xml:space="preserve">
-    <value>txtFindR</value>
-  </data>
-  <data name="btnFindPreviousR.Text" xml:space="preserve">
-    <value>Find Previous</value>
-  </data>
-  <data name="&gt;&gt;btnFindNextR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem34.Name" xml:space="preserve">
-    <value>toolStripMenuItem34</value>
-  </data>
-  <data name="&gt;&gt;lblSearchTypeR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="chkExplicitCaptureF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;btnFindAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem42.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkExplicitCaptureF.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsF</value>
-  </data>
-  <data name="&gt;&gt;cmdRecentFindF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtFindR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>370, 21</value>
-  </data>
-  <data name="&gt;&gt;grpOptionsF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem40.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkMarkLine.Name" xml:space="preserve">
-    <value>chkMarkLine</value>
-  </data>
-  <data name="nullCharactorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="&gt;&gt;statusStrip.Name" xml:space="preserve">
-    <value>statusStrip</value>
-  </data>
-  <data name="toolStripMenuItem50.Text" xml:space="preserve">
-    <value>$9 Numbered Group #9</value>
-  </data>
-  <data name="chkMarkLine.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="txtFindF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>59, 6</value>
-  </data>
-  <data name="chkMultilineF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem33.Name" xml:space="preserve">
-    <value>toolStripMenuItem33</value>
-  </data>
-  <data name="toolStripMenuItem20.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator8.Name" xml:space="preserve">
-    <value>toolStripSeparator8</value>
-  </data>
-  <data name="toolStripMenuItem18.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="toolStripMenuItem33.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem22.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="rdoRegexR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>247, 71</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem18.Name" xml:space="preserve">
-    <value>toolStripMenuItem18</value>
-  </data>
-  <data name="&gt;&gt;lblSearchTypeF.Name" xml:space="preserve">
-    <value>lblSearchTypeF</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem43.Name" xml:space="preserve">
-    <value>toolStripMenuItem43</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkWrapR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pnlStandardOptionsF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem29.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="chkWholeWordF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 17</value>
-  </data>
-  <data name="toolStripMenuItem31.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="cmdRecentFindR.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
-    <value>None</value>
-  </data>
-  <data name="&gt;&gt;chkMarkLine.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkMultilineR.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsR</value>
-  </data>
-  <data name="&gt;&gt;pnlRegexpOptionsR.Parent" xml:space="preserve">
-    <value>grdOptionsR</value>
-  </data>
-  <data name="&gt;&gt;chkSinglelineR.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsR</value>
-  </data>
-  <data name="rCarriageToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="mnuExtendedCharFindR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="btnClear.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="pnlStandardOptionsF.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tpgFind.Text" xml:space="preserve">
-    <value>Find</value>
-  </data>
-  <data name="pnlRegexpOptionsR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 17</value>
-  </data>
-  <data name="&gt;&gt;lblFindF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="chkWordStartR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 17</value>
-  </data>
-  <data name="&gt;&gt;btnReplacePrevious.Name" xml:space="preserve">
-    <value>btnReplacePrevious</value>
-  </data>
-  <data name="&gt;&gt;cmdExtCharAndRegExFindR.Name" xml:space="preserve">
-    <value>cmdExtCharAndRegExFindR</value>
-  </data>
-  <data name="&gt;&gt;chkMatchCaseR.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;pnlStandardOptionsF.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>FindReplaceDialog</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator6.Name" xml:space="preserve">
-    <value>toolStripSeparator6</value>
-  </data>
-  <data name="&gt;&gt;chkEcmaScriptF.Name" xml:space="preserve">
-    <value>chkEcmaScriptF</value>
-  </data>
-  <data name="&gt;&gt;chkSinglelineF.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsF</value>
-  </data>
-  <data name="tpgFind.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="chkWholeWordR.Text" xml:space="preserve">
-    <value>Whole Wor&amp;d</value>
-  </data>
-  <data name="btnFindNextR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="pnlRegexpOptionsF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 17</value>
-  </data>
-  <data name="&gt;&gt;lblReplace.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="&gt;&gt;lblSearchTypeF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="&gt;&gt;chkCompiledF.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;tpgFind.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkWordStartR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem53.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkSinglelineR.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;chkExplicitCaptureR.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;txtFindR.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="rdoExtendedR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 17</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem32.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="rdoStandardF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 17</value>
-  </data>
-  <data name="&gt;&gt;btnFindPreviousF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;statusStrip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.StatusStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkSinglelineF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 17</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="rdoExtendedF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="chkWrapR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="pnlRegexpOptionsF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>464, 57</value>
-  </data>
-  <data name="cmdExtCharAndRegExFindR.Text" xml:space="preserve">
-    <value>&gt;</value>
-  </data>
-  <data name="&gt;&gt;txtFindF.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="btnReplacePrevious.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="rdoStandardR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 17</value>
-  </data>
-  <data name="cmdExtCharAndRegExReplace.ToolTip" xml:space="preserve">
-    <value>Show a list of extended characters</value>
-  </data>
-  <data name="grpOptionsF.Text" xml:space="preserve">
-    <value>Options</value>
-  </data>
-  <data name="btnFindAll.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="toolStripMenuItem44.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="chkSinglelineF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;tpgFind.Name" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="cmdRecentFindR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 23</value>
-  </data>
-  <data name="&gt;&gt;pnlStandardOptionsR.Name" xml:space="preserve">
-    <value>pnlStandardOptionsR</value>
-  </data>
-  <data name="$this.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkSearchSelectionR.Name" xml:space="preserve">
-    <value>chkSearchSelectionR</value>
-  </data>
-  <data name="chkCompiledR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="chkIgnoreCaseF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 17</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdRecentFindR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="toolStripMenuItem55.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="&gt;&gt;grpFindAll.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="toolStripMenuItem2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="toolStripMenuItem38.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="toolStripMenuItem47.Text" xml:space="preserve">
-    <value>$ End of String or Line</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceF.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="chkCultureInvariantR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="rdoStandardF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="toolStripMenuItem48.Text" xml:space="preserve">
-    <value>$&amp;&amp; Entire Match</value>
-  </data>
-  <data name="&gt;&gt;rdoRegexR.Name" xml:space="preserve">
-    <value>rdoRegexR</value>
-  </data>
-  <data name="&gt;&gt;chkRightToLeftF.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsF</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendedF.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="mnuRecentFindR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="btnReplaceNext.Location" type="System.Drawing.Point, System.Drawing">
-    <value>364, 212</value>
-  </data>
-  <data name="&gt;&gt;pnlRegexpOptionsF.Name" xml:space="preserve">
-    <value>pnlRegexpOptionsF</value>
-  </data>
-  <data name="pnlStandardOptionsF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 17</value>
-  </data>
-  <data name="&gt;&gt;chkWrapF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoStandardF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtReplace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="chkWholeWordR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;btnClear.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkHighlightMatches.Text" xml:space="preserve">
-    <value>&amp;Highlight Matches</value>
-  </data>
-  <data name="chkEcmaScriptR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="cmdExtCharAndRegExFindR.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;chkCompiledR.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsR</value>
-  </data>
-  <data name="tabAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="lblReplace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 13</value>
-  </data>
-  <data name="chkSinglelineR.Text" xml:space="preserve">
-    <value>Singleline</value>
-  </data>
-  <data name="chkWordStartF.Text" xml:space="preserve">
-    <value>W&amp;ord Start</value>
-  </data>
-  <data name="btnClear.Location" type="System.Drawing.Point, System.Drawing">
-    <value>116, 37</value>
-  </data>
-  <data name="&gt;&gt;pnlStandardOptionsF.Parent" xml:space="preserve">
-    <value>grpOptionsF</value>
-  </data>
-  <data name="&gt;&gt;chkCompiledF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="lblFindF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tpgReplace.Text" xml:space="preserve">
-    <value>Replace</value>
-  </data>
-  <data name="&gt;&gt;lblFindF.Name" xml:space="preserve">
-    <value>lblFindF</value>
-  </data>
-  <data name="tabAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>488, 270</value>
-  </data>
-  <data name="toolStripMenuItem30.Text" xml:space="preserve">
-    <value>. Any Character</value>
-  </data>
-  <data name="chkSinglelineR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 37</value>
-  </data>
-  <data name="toolStripMenuItem17.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="mnuRegExCharFindR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem42.Name" xml:space="preserve">
-    <value>toolStripMenuItem42</value>
-  </data>
-  <data name="&gt;&gt;grdOptionsR.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="toolStripSeparator5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>257, 6</value>
-  </data>
-  <data name="chkHighlightMatches.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="chkEcmaScriptR.Text" xml:space="preserve">
-    <value>ECMA Script</value>
-  </data>
-  <data name="&gt;&gt;mnuRegExCharFindR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="tpgReplace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>480, 244</value>
-  </data>
-  <data name="grpFindAll.Text" xml:space="preserve">
-    <value>Find All</value>
-  </data>
-  <data name="&gt;&gt;cmdRecentReplace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem12.Text" xml:space="preserve">
-    <value>\s Whitespace (\S Non-Whitespace)</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem39.Name" xml:space="preserve">
-    <value>toolStripMenuItem39</value>
-  </data>
-  <data name="&gt;&gt;grdOptionsR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="&gt;&gt;btnFindPreviousF.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="rdoRegexR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkMarkLine.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;chkCultureInvariantF.Name" xml:space="preserve">
-    <value>chkCultureInvariantF</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem22.Name" xml:space="preserve">
-    <value>toolStripMenuItem22</value>
-  </data>
-  <data name="chkCultureInvariantR.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="chkCultureInvariantF.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 20</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem7.Name" xml:space="preserve">
-    <value>toolStripMenuItem7</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem49.Name" xml:space="preserve">
-    <value>toolStripMenuItem49</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem33.Text" xml:space="preserve">
-    <value>\s Whitespace (\S Non-Whitespace)</value>
-  </data>
-  <data name="toolStripMenuItem26.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;tpgReplace.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnFindAll.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="chkWholeWordF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 20</value>
-  </data>
-  <data name="&gt;&gt;chkHighlightMatches.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="chkMatchCaseF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;tpgReplace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkIgnoreCaseR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkWordStartF.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="tTabToolStripMenuItem1.Text" xml:space="preserve">
-    <value>\t Tab</value>
-  </data>
-  <data name="toolStripMenuItem40.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="chkWholeWordR.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;rdoRegexF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="&gt;&gt;rdoRegexF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem43.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;chkWholeWordF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkIgnoreCaseR.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="rdoExtendedF.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="tpgReplace.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="&gt;&gt;chkIgnoreCaseR.Name" xml:space="preserve">
-    <value>chkIgnoreCaseR</value>
-  </data>
-  <data name="chkCompiledF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 17</value>
-  </data>
-  <data name="&gt;&gt;chkSinglelineF.Name" xml:space="preserve">
-    <value>chkSinglelineF</value>
-  </data>
-  <data name="grdOptionsR.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="&gt;&gt;chkWholeWordF.Name" xml:space="preserve">
-    <value>chkWholeWordF</value>
-  </data>
-  <data name="grpOptionsF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 94</value>
-  </data>
-  <data name="&gt;&gt;mnuExtendedCharReplace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkRightToLeftR.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="pnlStandardOptionsR.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="chkRightToLeftF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 20</value>
-  </data>
-  <data name="tpgFind.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkCompiledF.Name" xml:space="preserve">
-    <value>chkCompiledF</value>
-  </data>
-  <data name="&gt;&gt;rdoStandardR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="toolStripMenuItem47.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem50.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="nameToolStripMenuItem.Text" xml:space="preserve">
-    <value>$(Name) Named Group</value>
-  </data>
-  <data name="cmdExtCharAndRegExFindR.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="rdoStandardF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>27, 71</value>
-  </data>
-  <data name="lblFindR.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem47.Name" xml:space="preserve">
-    <value>toolStripMenuItem47</value>
-  </data>
-  <data name="&gt;&gt;chkCompiledR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkEcmaScriptF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 37</value>
-  </data>
-  <data name="toolStripMenuItem10.Text" xml:space="preserve">
-    <value>\w Alphanumeric (\W Non-Aplhat)</value>
-  </data>
-  <data name="&gt;&gt;chkSinglelineF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkSearchSelectionF.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="chkSearchSelectionR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>375, 71</value>
-  </data>
-  <data name="chkIgnoreCaseR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 17</value>
-  </data>
-  <data name="&gt;&gt;rdoStandardR.Name" xml:space="preserve">
-    <value>rdoStandardR</value>
-  </data>
-  <data name="&gt;&gt;pnlRegexpOptionsR.Name" xml:space="preserve">
-    <value>pnlRegexpOptionsR</value>
-  </data>
-  <data name="chkMarkLine.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 17</value>
-  </data>
-  <data name="toolStripMenuItem6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="&gt;&gt;txtReplace.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="chkExplicitCaptureF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;toolStripSeparator2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem31.Text" xml:space="preserve">
-    <value>\w Alphanumeric (\W Non-Aplhat)</value>
-  </data>
-  <data name="btnFindPreviousF.Text" xml:space="preserve">
-    <value>Find &amp;Previous</value>
-  </data>
-  <data name="btnReplaceNext.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem54.Name" xml:space="preserve">
-    <value>toolStripMenuItem54</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem51.Name" xml:space="preserve">
-    <value>toolStripMenuItem51</value>
-  </data>
-  <data name="&gt;&gt;tpgReplace.Parent" xml:space="preserve">
-    <value>tabAll</value>
-  </data>
-  <data name="chkCultureInvariantR.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;nameToolStripMenuItem.Name" xml:space="preserve">
-    <value>nameToolStripMenuItem</value>
-  </data>
-  <data name="grpOptionsF.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem25.Name" xml:space="preserve">
-    <value>toolStripMenuItem25</value>
-  </data>
-  <data name="cmdExtCharAndRegExFindF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 23</value>
-  </data>
-  <data name="toolStripMenuItem4.Text" xml:space="preserve">
-    <value>\0 Null Character</value>
-  </data>
-  <data name="toolStripMenuItem7.Text" xml:space="preserve">
-    <value>\t Tab</value>
-  </data>
-  <data name="&gt;&gt;pnlStandardOptionsF.Name" xml:space="preserve">
-    <value>pnlStandardOptionsF</value>
-  </data>
-  <data name="&gt;&gt;chkExplicitCaptureF.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;btnReplacePrevious.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="chkExplicitCaptureR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;chkWholeWordR.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="btnFindPreviousF.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkSearchSelectionF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>375, 71</value>
-  </data>
-  <data name="toolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="chkMultilineF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 17</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem52.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="chkWrapR.Text" xml:space="preserve">
-    <value>&amp;Wrap</value>
-  </data>
-  <data name="&gt;&gt;pnlStandardOptionsR.Parent" xml:space="preserve">
-    <value>grdOptionsR</value>
-  </data>
-  <data name="&gt;&gt;btnClear.Name" xml:space="preserve">
-    <value>btnClear</value>
-  </data>
-  <data name="&gt;&gt;rdoRegexF.Name" xml:space="preserve">
-    <value>rdoRegexF</value>
-  </data>
-  <data name="&gt;&gt;chkIgnorePatternWhitespaceF.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsF</value>
-  </data>
-  <data name="&gt;&gt;chkCompiledR.Name" xml:space="preserve">
-    <value>chkCompiledR</value>
-  </data>
-  <data name="txtFindF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>370, 21</value>
-  </data>
-  <data name="mnuRecentFindR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>36, 4</value>
-  </data>
-  <data name="chkMultilineF.Text" xml:space="preserve">
-    <value>Multiline</value>
-  </data>
-  <data name="toolStripMenuItem15.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem35.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="rdoExtendedR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>102, 71</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>113, 37</value>
-  </data>
-  <data name="toolStripMenuItem16.Text" xml:space="preserve">
-    <value>[a-zA-Z] Specified Set ([^a...] Not in Set)</value>
-  </data>
-  <data name="txtFindF.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;chkIgnoreCaseF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoStandardR.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;chkExplicitCaptureR.Name" xml:space="preserve">
-    <value>chkExplicitCaptureR</value>
-  </data>
-  <data name="btnReplaceNext.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 23</value>
-  </data>
-  <data name="toolStripMenuItem7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>504, 331</value>
-  </data>
-  <data name="&gt;&gt;cmdExtCharAndRegExFindF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="&gt;&gt;chkCultureInvariantR.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsR</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem45.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cmdRecentFindR.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="cmdExtCharAndRegExFindR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>453, 5</value>
-  </data>
-  <data name="mnuExtendedCharFindR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>175, 114</value>
-  </data>
-  <data name="rdoExtendedF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>102, 71</value>
-  </data>
-  <data name="toolStripMenuItem37.Text" xml:space="preserve">
-    <value>\r Carriage Return</value>
-  </data>
-  <data name="chkCompiledR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;lblFindR.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="tpgReplace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="txtFindR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>59, 6</value>
-  </data>
-  <data name="chkRightToLeftR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 17</value>
-  </data>
-  <data name="&gt;&gt;chkExplicitCaptureF.Name" xml:space="preserve">
-    <value>chkExplicitCaptureF</value>
-  </data>
-  <data name="btnFindPreviousF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 23</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem44.Name" xml:space="preserve">
-    <value>toolStripMenuItem44</value>
-  </data>
-  <data name="toolStripMenuItem24.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="cmdExtCharAndRegExFindF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>453, 5</value>
-  </data>
-  <data name="mnuExtendedCharFindF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>175, 114</value>
-  </data>
-  <data name="rdoExtendedR.Text" xml:space="preserve">
-    <value>E&amp;xtended (\n, \r, \t, \0)</value>
-  </data>
-  <data name="chkWordStartF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 17</value>
-  </data>
-  <data name="chkEcmaScriptF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;grdOptionsR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="btnFindNextF.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="chkWholeWordR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 17</value>
-  </data>
-  <data name="lblStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 17</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem34.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkMatchCaseF.Parent" xml:space="preserve">
-    <value>pnlStandardOptionsF</value>
-  </data>
-  <data name="chkIgnoreCaseF.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem17.Name" xml:space="preserve">
-    <value>toolStripMenuItem17</value>
-  </data>
-  <data name="toolStripMenuItem35.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;btnFindPreviousF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="rdoRegexR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 17</value>
-  </data>
-  <data name="toolStripMenuItem29.Text" xml:space="preserve">
-    <value>\0 Null Character</value>
-  </data>
-  <data name="&gt;&gt;cmdExtCharAndRegExFindR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="chkWordStartF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem4.Name" xml:space="preserve">
-    <value>toolStripMenuItem4</value>
-  </data>
-  <data name="toolStripMenuItem45.Text" xml:space="preserve">
-    <value>(?&lt;Name&gt;) Named Capture</value>
-  </data>
-  <data name="chkRightToLeftF.Text" xml:space="preserve">
-    <value>Right To Left</value>
-  </data>
-  <data name="chkSinglelineR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 17</value>
-  </data>
-  <data name="chkRightToLeftF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkEcmaScriptR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdRecentReplace.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="&gt;&gt;nameToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkWrapF.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;mnuRecentFindR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="btnFindNextR.Text" xml:space="preserve">
-    <value>Find Next</value>
-  </data>
-  <data name="txtReplace.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="pnlRegexpOptionsR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>464, 57</value>
-  </data>
-  <data name="rdoStandardF.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="btnReplaceAll.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendedF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="&gt;&gt;chkIgnorePatternWhitespaceF.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="rdoStandardF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;btnFindNextF.Name" xml:space="preserve">
-    <value>btnFindNextF</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem37.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="lblReplace.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;chkHighlightMatches.Parent" xml:space="preserve">
-    <value>grpFindAll</value>
-  </data>
-  <data name="toolStripMenuItem14.Text" xml:space="preserve">
-    <value>\r\n Windows New Line</value>
-  </data>
-  <data name="mnuRegExCharFindF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>261, 424</value>
-  </data>
-  <data name="chkHighlightMatches.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 17</value>
-  </data>
-  <data name="&gt;&gt;rdoRegexF.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;lblFindR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="chkWholeWordF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="tTabToolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>488, 292</value>
-  </data>
-  <data name="cmdRecentFindR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>430, 5</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem47.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkExplicitCaptureF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>113, 3</value>
-  </data>
-  <data name="mnuRegExCharFindR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>261, 424</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem35.Name" xml:space="preserve">
-    <value>toolStripMenuItem35</value>
-  </data>
-  <data name="pnlRegexpOptionsR.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="&gt;&gt;mnuExtendedCharFindF.Name" xml:space="preserve">
-    <value>mnuExtendedCharFindF</value>
-  </data>
-  <data name="&gt;&gt;chkSearchSelectionR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="rdoStandardR.Text" xml:space="preserve">
-    <value>&amp;Standard</value>
-  </data>
-  <data name="&gt;&gt;chkMultilineF.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsF</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="rdoStandardR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkSearchSelectionR.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="btnFindAll.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkEcmaScriptR.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsR</value>
-  </data>
-  <data name="chkWholeWordF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="chkExplicitCaptureR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>113, 3</value>
-  </data>
-  <data name="toolStripMenuItem38.Text" xml:space="preserve">
-    <value>\t Tab</value>
-  </data>
-  <data name="chkExplicitCaptureF.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;chkExplicitCaptureF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkMultilineF.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="chkExplicitCaptureR.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="grdOptionsR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 94</value>
-  </data>
-  <data name="toolStripMenuItem39.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem29.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem56.Name" xml:space="preserve">
-    <value>toolStripMenuItem56</value>
-  </data>
-  <data name="mnuRecentReplace.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;rdoExtendedR.Name" xml:space="preserve">
-    <value>rdoExtendedR</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem44.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem21.Name" xml:space="preserve">
-    <value>toolStripMenuItem21</value>
-  </data>
-  <data name="toolStripMenuItem5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem27.Name" xml:space="preserve">
-    <value>toolStripMenuItem27</value>
-  </data>
-  <data name="cmdExtCharAndRegExFindF.ToolTip" xml:space="preserve">
-    <value>Show a list of extended characters</value>
-  </data>
-  <data name="nNewLineToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem24.Name" xml:space="preserve">
-    <value>toolStripMenuItem24</value>
-  </data>
-  <data name="toolStripMenuItem48.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="&gt;&gt;rCarriageToolStripMenuItem.Name" xml:space="preserve">
-    <value>rCarriageToolStripMenuItem</value>
-  </data>
-  <data name="btnReplacePrevious.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="tpgFind.Size" type="System.Drawing.Size, System.Drawing">
-    <value>480, 244</value>
-  </data>
-  <data name="&gt;&gt;chkRightToLeftF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem1.Name" xml:space="preserve">
-    <value>toolStripMenuItem1</value>
-  </data>
-  <data name="cmdRecentReplace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>430, 27</value>
-  </data>
-  <data name="toolStripMenuItem23.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="toolStripMenuItem50.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="toolStripMenuItem22.Text" xml:space="preserve">
-    <value>? As Few as Possible (i.e. *?, +? or ??)</value>
-  </data>
-  <data name="cmdExtCharAndRegExReplace.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="chkMatchCaseF.Text" xml:space="preserve">
-    <value>Match &amp;Case</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem31.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkSearchSelectionR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>105, 17</value>
-  </data>
-  <data name="&gt;&gt;chkMultilineF.Name" xml:space="preserve">
-    <value>chkMultilineF</value>
-  </data>
-  <data name="rdoExtendedF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkEcmaScriptR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;chkIgnorePatternWhitespaceF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkEcmaScriptR.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="toolStripMenuItem37.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="toolStripMenuItem51.Text" xml:space="preserve">
-    <value>$8 Numbered Group #8</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem11.Name" xml:space="preserve">
-    <value>toolStripMenuItem11</value>
-  </data>
-  <data name="&gt;&gt;btnReplaceAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkSearchSelectionR.Text" xml:space="preserve">
-    <value>Search Selection</value>
-  </data>
-  <data name="&gt;&gt;mnuRegExCharReplace.Name" xml:space="preserve">
-    <value>mnuRegExCharReplace</value>
-  </data>
-  <data name="nameToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="chkCompiledR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 17</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem36.Name" xml:space="preserve">
-    <value>toolStripMenuItem36</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator7.Name" xml:space="preserve">
-    <value>toolStripSeparator7</value>
-  </data>
-  <data name="chkExplicitCaptureR.Text" xml:space="preserve">
-    <value>E&amp;xplicit Capture</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceF.Text" xml:space="preserve">
-    <value>I&amp;gnore Pattern Whitespace</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkSearchSelectionR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem40.Name" xml:space="preserve">
-    <value>toolStripMenuItem40</value>
-  </data>
-  <data name="&gt;&gt;btnReplaceAll.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="rCarriageToolStripMenuItem.Text" xml:space="preserve">
-    <value>\r Carriage Return</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem46.Name" xml:space="preserve">
-    <value>toolStripMenuItem46</value>
-  </data>
-  <data name="&gt;&gt;grpFindAll.Name" xml:space="preserve">
-    <value>grpFindAll</value>
-  </data>
-  <data name="&gt;&gt;statusStrip.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="rdoStandardF.Text" xml:space="preserve">
-    <value>&amp;Standard</value>
-  </data>
-  <data name="txtReplace.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;btnReplaceNext.Name" xml:space="preserve">
-    <value>btnReplaceNext</value>
-  </data>
-  <data name="lblSearchTypeR.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="toolStripMenuItem6.Text" xml:space="preserve">
-    <value>\r Carriage Return</value>
-  </data>
-  <data name="toolStripMenuItem28.Text" xml:space="preserve">
-    <value>\t Tab</value>
-  </data>
-  <data name="toolStripMenuItem5.Text" xml:space="preserve">
-    <value>\n Line Feed</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendedF.Name" xml:space="preserve">
-    <value>rdoExtendedF</value>
-  </data>
-  <data name="grdOptionsR.Text" xml:space="preserve">
-    <value>Options</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator3.Name" xml:space="preserve">
-    <value>toolStripSeparator3</value>
-  </data>
-  <data name="btnReplaceAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 212</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem13.Name" xml:space="preserve">
-    <value>toolStripMenuItem13</value>
-  </data>
-  <data name="btnFindPreviousR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>251, 188</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceR.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem45.Name" xml:space="preserve">
-    <value>toolStripMenuItem45</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem36.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkMarkLine.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="statusStrip.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;pnlStandardOptionsR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
-    <value>toolTip1</value>
-  </data>
-  <data name="pnlRegexpOptionsF.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="rdoRegexR.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="chkMultilineR.Text" xml:space="preserve">
-    <value>Multiline</value>
-  </data>
-  <data name="btnFindPreviousF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>364, 188</value>
-  </data>
-  <data name="&gt;&gt;pnlRegexpOptionsF.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="pnlStandardOptionsR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>464, 57</value>
-  </data>
-  <data name="toolStripMenuItem11.Text" xml:space="preserve">
-    <value>\d Digit (\D Non-Digit)</value>
-  </data>
-  <data name="chkWrapF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendedR.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem33.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="btnFindNextF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 23</value>
-  </data>
-  <data name="&gt;&gt;mnuRecentFindR.Name" xml:space="preserve">
-    <value>mnuRecentFindR</value>
-  </data>
-  <data name="toolStripMenuItem32.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="chkSearchSelectionR.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="lblSearchTypeR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 52</value>
-  </data>
-  <data name="&gt;&gt;txtFindR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="btnFindPreviousR.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem43.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkCompiledF.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsF</value>
-  </data>
-  <data name="btnFindNextR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 23</value>
-  </data>
-  <data name="btnReplaceAll.Text" xml:space="preserve">
-    <value>Replace &amp;All</value>
-  </data>
-  <data name="toolStripMenuItem57.Text" xml:space="preserve">
-    <value>$2 Numbered Group #2</value>
-  </data>
-  <data name="lblReplace.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="grpFindAll.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="chkMatchCaseF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;mnuRegExCharFindR.Name" xml:space="preserve">
-    <value>mnuRegExCharFindR</value>
-  </data>
-  <data name="chkIgnoreCaseF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>113, 20</value>
-  </data>
-  <data name="chkIgnoreCaseF.Text" xml:space="preserve">
-    <value>&amp;Ignore Case</value>
-  </data>
-  <data name="chkWrapR.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="chkSearchSelectionF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>105, 17</value>
-  </data>
-  <data name="toolStripMenuItem54.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="pnlStandardOptionsF.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="chkEcmaScriptF.Text" xml:space="preserve">
-    <value>ECMA Script</value>
-  </data>
-  <data name="&gt;&gt;chkMatchCaseR.Parent" xml:space="preserve">
-    <value>pnlStandardOptionsR</value>
-  </data>
-  <data name="&gt;&gt;cmdRecentReplace.Name" xml:space="preserve">
-    <value>cmdRecentReplace</value>
-  </data>
-  <data name="&gt;&gt;chkEcmaScriptR.Name" xml:space="preserve">
-    <value>chkEcmaScriptR</value>
-  </data>
-  <data name="btnReplacePrevious.Location" type="System.Drawing.Point, System.Drawing">
-    <value>364, 188</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem50.Name" xml:space="preserve">
-    <value>toolStripMenuItem50</value>
-  </data>
-  <data name="&gt;&gt;chkMultilineR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cmdRecentFindR.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="chkWrapF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkWholeWordR.Parent" xml:space="preserve">
-    <value>pnlStandardOptionsR</value>
-  </data>
-  <data name="cmdExtCharAndRegExFindR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 23</value>
-  </data>
-  <data name="chkEcmaScriptF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 17</value>
-  </data>
-  <data name="rdoRegexR.Text" xml:space="preserve">
-    <value>Regular &amp;Expression</value>
-  </data>
-  <data name="&gt;&gt;lblReplace.Name" xml:space="preserve">
-    <value>lblReplace</value>
-  </data>
-  <data name="toolStripMenuItem49.Text" xml:space="preserve">
-    <value>$1 Numbered Group #1</value>
-  </data>
-  <data name="&gt;&gt;mnuRegExCharReplace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFindPreviousR.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;chkCultureInvariantR.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>257, 6</value>
-  </data>
-  <data name="btnFindNextF.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;mnuRegExCharFindF.Name" xml:space="preserve">
-    <value>mnuRegExCharFindF</value>
-  </data>
-  <data name="&gt;&gt;grpOptionsF.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="mnuRegExCharReplace.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem23.Name" xml:space="preserve">
-    <value>toolStripMenuItem23</value>
-  </data>
-  <data name="&gt;&gt;cmdExtCharAndRegExReplace.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="txtFindF.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="&gt;&gt;chkCultureInvariantR.Name" xml:space="preserve">
-    <value>chkCultureInvariantR</value>
-  </data>
-  <data name="chkWholeWordR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 20</value>
-  </data>
-  <data name="chkHighlightMatches.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 37</value>
-  </data>
-  <data name="tabAll.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblFindR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;grpOptionsF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="txtFindR.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="&gt;&gt;chkRightToLeftR.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsR</value>
-  </data>
-  <data name="mnuRecentReplace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>36, 4</value>
-  </data>
-  <data name="grdOptionsR.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;btnFindPreviousF.Name" xml:space="preserve">
-    <value>btnFindPreviousF</value>
-  </data>
-  <data name="&gt;&gt;cmdExtCharAndRegExFindR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;nullCharactorToolStripMenuItem.Name" xml:space="preserve">
-    <value>nullCharactorToolStripMenuItem</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceR.Text" xml:space="preserve">
-    <value>I&amp;gnore Pattern Whitespace</value>
-  </data>
-  <data name="chkMultilineR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 17</value>
-  </data>
-  <data name="toolStripMenuItem21.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;nNewLineToolStripMenuItem.Name" xml:space="preserve">
-    <value>nNewLineToolStripMenuItem</value>
-  </data>
-  <data name="toolStripMenuItem8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="toolStripMenuItem56.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="&gt;&gt;chkSearchSelectionF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem26.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem56.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="grpFindAll.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;pnlStandardOptionsR.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="chkRightToLeftF.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="btnReplacePrevious.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 23</value>
-  </data>
-  <data name="&gt;&gt;chkSearchSelectionF.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;lblSearchTypeR.Name" xml:space="preserve">
-    <value>lblSearchTypeR</value>
-  </data>
-  <data name="rdoRegexR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem2.Name" xml:space="preserve">
-    <value>toolStripMenuItem2</value>
-  </data>
-  <data name="chkWrapR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>375, 52</value>
-  </data>
-  <data name="toolStripMenuItem55.Text" xml:space="preserve">
-    <value>$4 Numbered Group #4</value>
-  </data>
-  <data name="rdoExtendedR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem5.Name" xml:space="preserve">
-    <value>toolStripMenuItem5</value>
-  </data>
-  <data name="toolStripMenuItem13.Text" xml:space="preserve">
-    <value>\r\n Windows New Line</value>
-  </data>
-  <data name="&gt;&gt;mnuRegExCharFindF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkSinglelineF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="pnlStandardOptionsF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="cmdRecentFindF.ToolTip" xml:space="preserve">
-    <value>Show a list of recent search strings</value>
-  </data>
-  <data name="btnReplacePrevious.Text" xml:space="preserve">
-    <value>Replace &amp;Previous</value>
-  </data>
-  <data name="&gt;&gt;tTabToolStripMenuItem1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="tabAll.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="chkMatchCaseF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 17</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem38.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkMatchCaseR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 17</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem32.Name" xml:space="preserve">
-    <value>toolStripMenuItem32</value>
-  </data>
-  <data name="toolStripMenuItem28.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="chkWrapF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>375, 52</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator1.Name" xml:space="preserve">
-    <value>toolStripSeparator1</value>
-  </data>
-  <data name="tpgReplace.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;lblReplace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="rdoExtendedF.Text" xml:space="preserve">
-    <value>E&amp;xtended (\n, \r, \t, \0)</value>
-  </data>
-  <data name="chkMarkLine.Text" xml:space="preserve">
-    <value>&amp;Mark Line</value>
-  </data>
-  <data name="pnlStandardOptionsR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkMultilineR.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="chkRightToLeftF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 17</value>
-  </data>
-  <data name="&gt;&gt;chkWholeWordF.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem48.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem23.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;grdOptionsR.Name" xml:space="preserve">
-    <value>grdOptionsR</value>
-  </data>
-  <data name="chkExplicitCaptureF.Text" xml:space="preserve">
-    <value>E&amp;xplicit Capture</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem3.Name" xml:space="preserve">
-    <value>toolStripMenuItem3</value>
-  </data>
-  <data name="toolStripMenuItem32.Text" xml:space="preserve">
-    <value>\d Digit (\D Non-Digit)</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem19.Name" xml:space="preserve">
-    <value>toolStripMenuItem19</value>
-  </data>
-  <data name="&gt;&gt;chkWordStartR.Name" xml:space="preserve">
-    <value>chkWordStartR</value>
-  </data>
-  <data name="&gt;&gt;txtFindR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="&gt;&gt;tabAll.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="grpFindAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 65</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkHighlightMatches.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;chkHighlightMatches.Name" xml:space="preserve">
-    <value>chkHighlightMatches</value>
-  </data>
-  <data name="&gt;&gt;lblSearchTypeR.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="rdoRegexF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 17</value>
-  </data>
-  <data name="toolStripMenuItem42.Text" xml:space="preserve">
-    <value>? Zero or More Repetitions</value>
-  </data>
-  <data name="toolStripMenuItem3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="&gt;&gt;lblSearchTypeR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem24.Text" xml:space="preserve">
-    <value>$ End of String or Line</value>
-  </data>
-  <data name="chkCompiledR.Text" xml:space="preserve">
-    <value>&amp;Compiled</value>
-  </data>
-  <data name="&gt;&gt;pnlRegexpOptionsR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem45.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="btnReplacePrevious.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="toolStripMenuItem20.Text" xml:space="preserve">
-    <value>( ) Numbered Capture</value>
-  </data>
-  <data name="&gt;&gt;chkSearchSelectionF.Name" xml:space="preserve">
-    <value>chkSearchSelectionF</value>
-  </data>
-  <data name="txtReplace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>59, 28</value>
-  </data>
-  <data name="&gt;&gt;chkIgnoreCaseF.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="lblReplace.Text" xml:space="preserve">
-    <value>&amp;Replace</value>
-  </data>
-  <data name="chkWrapR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 17</value>
-  </data>
-  <data name="chkWordStartF.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="toolStripMenuItem56.Text" xml:space="preserve">
-    <value>$3 Numbered Group #3</value>
-  </data>
-  <data name="chkEcmaScriptF.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="chkWordStartR.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="rdoRegexF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;txtReplace.Name" xml:space="preserve">
-    <value>txtReplace</value>
-  </data>
-  <data name="toolStripMenuItem17.Text" xml:space="preserve">
-    <value>* Any Number of Repetitions</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem41.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkWrapF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 17</value>
-  </data>
-  <data name="lblSearchTypeF.Text" xml:space="preserve">
-    <value>Search Type</value>
-  </data>
-  <data name="lblFindF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 10</value>
-  </data>
-  <data name="&gt;&gt;chkSearchSelectionF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;txtFindF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkMatchCaseR.Name" xml:space="preserve">
-    <value>chkMatchCaseR</value>
-  </data>
-  <data name="lblSearchTypeR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;mnuRecentFindF.Name" xml:space="preserve">
-    <value>mnuRecentFindF</value>
-  </data>
-  <data name="&gt;&gt;tpgReplace.Name" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="chkWrapF.Text" xml:space="preserve">
-    <value>&amp;Wrap</value>
-  </data>
-  <data name="chkCompiledF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cmdExtCharAndRegExFindF.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="chkSearchSelectionF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;rdoRegexR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="grdOptionsR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>470, 77</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>113, 37</value>
-  </data>
-  <data name="&gt;&gt;chkSinglelineR.Name" xml:space="preserve">
-    <value>chkSinglelineR</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkIgnoreCaseF.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsF</value>
-  </data>
-  <data name="lblFindF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>27, 13</value>
-  </data>
-  <data name="chkMultilineR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 3</value>
-  </data>
-  <data name="btnFindNextF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>364, 212</value>
-  </data>
-  <data name="&gt;&gt;rdoStandardF.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;chkWrapR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="cmdRecentFindF.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="chkSinglelineF.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;txtFindF.Name" xml:space="preserve">
-    <value>txtFindF</value>
-  </data>
-  <data name="&gt;&gt;pnlRegexpOptionsR.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="lblFindR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>27, 13</value>
-  </data>
-  <data name="&gt;&gt;chkIgnoreCaseR.Parent" xml:space="preserve">
-    <value>pnlRegexpOptionsR</value>
-  </data>
-  <data name="rdoStandardR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>27, 71</value>
-  </data>
-  <data name="&gt;&gt;chkIgnorePatternWhitespaceF.Name" xml:space="preserve">
-    <value>chkIgnorePatternWhitespaceF</value>
-  </data>
-  <data name="btnFindPreviousR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="chkMatchCaseR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="toolStripSeparator4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>257, 6</value>
-  </data>
-  <data name="toolStripMenuItem40.Text" xml:space="preserve">
-    <value>* Any Number of Repetitions</value>
-  </data>
-  <data name="&gt;&gt;lblStatus.Name" xml:space="preserve">
-    <value>lblStatus</value>
-  </data>
-  <data name="cmdExtCharAndRegExReplace.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="mnuExtendedCharReplace.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkIgnorePatternWhitespaceR.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="btnReplaceNext.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkMatchCaseF.Name" xml:space="preserve">
-    <value>chkMatchCaseF</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="pnlRegexpOptionsF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;rdoRegexR.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem55.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem12.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="txtFindR.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="rdoRegexF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>247, 71</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem52.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="rdoStandardR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkHighlightMatches.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;btnFindPreviousR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="toolStripMenuItem27.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;lblSearchTypeF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="rdoExtendedF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>139, 17</value>
-  </data>
-  <data name="chkCompiledF.Text" xml:space="preserve">
-    <value>&amp;Compiled</value>
-  </data>
-  <data name="&gt;&gt;chkRightToLeftF.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="rdoExtendedR.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="chkExplicitCaptureR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 17</value>
-  </data>
-  <data name="nullCharactorToolStripMenuItem.Text" xml:space="preserve">
-    <value>\0 Null Character</value>
-  </data>
-  <data name="mnuRecentFindF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="toolStripMenuItem53.Text" xml:space="preserve">
-    <value>$6 Numbered Group #6</value>
-  </data>
-  <data name="rdoRegexF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblSearchTypeR.Text" xml:space="preserve">
-    <value>Search Type</value>
-  </data>
-  <data name="&gt;&gt;chkWrapR.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;chkMatchCaseF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnReplaceAll.Name" xml:space="preserve">
-    <value>btnReplaceAll</value>
-  </data>
-  <data name="&gt;&gt;chkWordStartF.Name" xml:space="preserve">
-    <value>chkWordStartF</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem38.Name" xml:space="preserve">
-    <value>toolStripMenuItem38</value>
-  </data>
-  <data name="&gt;&gt;btnFindNextF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;statusStrip.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="cmdExtCharAndRegExFindR.ToolTip" xml:space="preserve">
-    <value>Show a list of extended characters</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem57.Name" xml:space="preserve">
-    <value>toolStripMenuItem57</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendedR.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="&gt;&gt;btnReplaceNext.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFindNextR.Name" xml:space="preserve">
-    <value>btnFindNextR</value>
-  </data>
-  <data name="chkWordStartF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 37</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem48.Name" xml:space="preserve">
-    <value>toolStripMenuItem48</value>
-  </data>
-  <data name="lblFindF.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem15.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="statusStrip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 270</value>
-  </data>
-  <data name="txtReplace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>370, 21</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lblFindR.Name" xml:space="preserve">
-    <value>lblFindR</value>
-  </data>
-  <data name="lblSearchTypeR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;txtReplace.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="chkMultilineR.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="chkWordStartR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 37</value>
-  </data>
-  <data name="toolStripMenuItem16.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem14.Name" xml:space="preserve">
-    <value>toolStripMenuItem14</value>
-  </data>
-  <data name="btnFindAll.Text" xml:space="preserve">
-    <value>Find &amp;All</value>
-  </data>
-  <data name="&gt;&gt;chkCompiledR.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="lblSearchTypeR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
-  </data>
-  <data name="toolStripMenuItem46.Text" xml:space="preserve">
-    <value>^ Beginning of String or Line</value>
-  </data>
-  <data name="chkCultureInvariantR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>108, 17</value>
-  </data>
-  <data name="chkEcmaScriptF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="btnFindPreviousF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="chkRightToLeftR.Text" xml:space="preserve">
-    <value>Right To Left</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem14.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkHighlightMatches.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkRightToLeftR.Name" xml:space="preserve">
-    <value>chkRightToLeftR</value>
-  </data>
-  <data name="&gt;&gt;cmdRecentReplace.ZOrder" xml:space="preserve">
-    <value>18</value>
-  </data>
-  <data name="lblSearchTypeF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
-  </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>Find and Replace</value>
   </data>
   <data name="chkCultureInvariantF.Size" type="System.Drawing.Size, System.Drawing">
     <value>108, 17</value>
   </data>
-  <data name="&gt;&gt;mnuExtendedCharFindR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="chkCultureInvariantF.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="&gt;&gt;chkMultilineR.Name" xml:space="preserve">
-    <value>chkMultilineR</value>
+  <data name="chkCultureInvariantF.Text" xml:space="preserve">
+    <value>C&amp;ulture Invariant</value>
   </data>
-  <data name="&gt;&gt;rdoStandardF.Name" xml:space="preserve">
-    <value>rdoStandardF</value>
+  <data name="&gt;&gt;chkCultureInvariantF.Name" xml:space="preserve">
+    <value>chkCultureInvariantF</value>
   </data>
-  <data name="btnReplaceNext.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="&gt;&gt;chkCultureInvariantF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="toolStripMenuItem9.Text" xml:space="preserve">
-    <value>. Any Character</value>
+  <data name="&gt;&gt;chkCultureInvariantF.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsF</value>
   </data>
-  <data name="btnReplaceAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 23</value>
+  <data name="&gt;&gt;chkCultureInvariantF.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="chkCompiledF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="chkCompiledF.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 3</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem8.Name" xml:space="preserve">
-    <value>toolStripMenuItem8</value>
+  <data name="chkCompiledF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 17</value>
   </data>
-  <data name="pnlStandardOptionsF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>464, 57</value>
+  <data name="chkCompiledF.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="chkSearchSelectionF.ToolTip" xml:space="preserve">
-    <value />
+  <data name="chkCompiledF.Text" xml:space="preserve">
+    <value>&amp;Compiled</value>
   </data>
-  <data name="&gt;&gt;chkWordStartF.Type" xml:space="preserve">
+  <data name="&gt;&gt;chkCompiledF.Name" xml:space="preserve">
+    <value>chkCompiledF</value>
+  </data>
+  <data name="&gt;&gt;chkCompiledF.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="toolStripMenuItem54.Text" xml:space="preserve">
-    <value>$5 Numbered Group #5</value>
+  <data name="&gt;&gt;chkCompiledF.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsF</value>
   </data>
-  <data name="&gt;&gt;chkWholeWordR.Type" xml:space="preserve">
+  <data name="&gt;&gt;chkCompiledF.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="pnlRegexpOptionsF.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pnlRegexpOptionsF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 17</value>
+  </data>
+  <data name="pnlRegexpOptionsF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>464, 57</value>
+  </data>
+  <data name="pnlRegexpOptionsF.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pnlRegexpOptionsF.Name" xml:space="preserve">
+    <value>pnlRegexpOptionsF</value>
+  </data>
+  <data name="&gt;&gt;pnlRegexpOptionsF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pnlRegexpOptionsF.Parent" xml:space="preserve">
+    <value>grpOptionsF</value>
+  </data>
+  <data name="&gt;&gt;pnlRegexpOptionsF.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="grpOptionsF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 94</value>
+  </data>
+  <data name="grpOptionsF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>470, 77</value>
+  </data>
+  <data name="grpOptionsF.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="grpOptionsF.Text" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="&gt;&gt;grpOptionsF.Name" xml:space="preserve">
+    <value>grpOptionsF</value>
+  </data>
+  <data name="&gt;&gt;grpOptionsF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpOptionsF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;grpOptionsF.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="lblSearchTypeF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblSearchTypeF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 52</value>
+  </data>
+  <data name="lblSearchTypeF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 13</value>
+  </data>
+  <data name="lblSearchTypeF.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="lblSearchTypeF.Text" xml:space="preserve">
+    <value>Search Type</value>
+  </data>
+  <data name="&gt;&gt;lblSearchTypeF.Name" xml:space="preserve">
+    <value>lblSearchTypeF</value>
+  </data>
+  <data name="&gt;&gt;lblSearchTypeF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSearchTypeF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;lblSearchTypeF.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="rdoRegexF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoRegexF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>247, 71</value>
+  </data>
+  <data name="rdoRegexF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 17</value>
+  </data>
+  <data name="rdoRegexF.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="rdoRegexF.Text" xml:space="preserve">
+    <value>Regular &amp;Expression</value>
+  </data>
+  <data name="&gt;&gt;rdoRegexF.Name" xml:space="preserve">
+    <value>rdoRegexF</value>
+  </data>
+  <data name="&gt;&gt;rdoRegexF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoRegexF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;rdoRegexF.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="rdoStandardF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoStandardF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>27, 71</value>
+  </data>
+  <data name="rdoStandardF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 17</value>
+  </data>
+  <data name="rdoStandardF.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="rdoStandardF.Text" xml:space="preserve">
+    <value>&amp;Standard</value>
+  </data>
+  <data name="&gt;&gt;rdoStandardF.Name" xml:space="preserve">
+    <value>rdoStandardF</value>
+  </data>
+  <data name="&gt;&gt;rdoStandardF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoStandardF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;rdoStandardF.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="lblFindF.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblFindF.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 10</value>
+  </data>
+  <data name="lblFindF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>27, 13</value>
+  </data>
+  <data name="lblFindF.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblFindF.Text" xml:space="preserve">
+    <value>&amp;Find</value>
+  </data>
+  <data name="&gt;&gt;lblFindF.Name" xml:space="preserve">
+    <value>lblFindF</value>
+  </data>
+  <data name="&gt;&gt;lblFindF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFindF.Parent" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;lblFindF.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="tpgFind.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpgFind.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpgFind.Size" type="System.Drawing.Size, System.Drawing">
+    <value>480, 244</value>
+  </data>
+  <data name="tpgFind.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpgFind.Text" xml:space="preserve">
+    <value>Find</value>
+  </data>
+  <data name="&gt;&gt;tpgFind.Name" xml:space="preserve">
+    <value>tpgFind</value>
+  </data>
+  <data name="&gt;&gt;tpgFind.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpgFind.Parent" xml:space="preserve">
+    <value>tabAll</value>
+  </data>
+  <data name="&gt;&gt;tpgFind.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnFindNextR.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnFindNextR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>251, 212</value>
+  </data>
+  <data name="btnFindNextR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 23</value>
+  </data>
+  <data name="btnFindNextR.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="btnFindNextR.Text" xml:space="preserve">
+    <value>Find Next</value>
+  </data>
+  <data name="&gt;&gt;btnFindNextR.Name" xml:space="preserve">
+    <value>btnFindNextR</value>
+  </data>
+  <data name="&gt;&gt;btnFindNextR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnFindNextR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;btnFindNextR.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="btnFindPreviousR.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnFindPreviousR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>251, 188</value>
+  </data>
+  <data name="btnFindPreviousR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 23</value>
+  </data>
+  <data name="btnFindPreviousR.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="btnFindPreviousR.Text" xml:space="preserve">
+    <value>Find Previous</value>
+  </data>
+  <data name="&gt;&gt;btnFindPreviousR.Name" xml:space="preserve">
+    <value>btnFindPreviousR</value>
+  </data>
+  <data name="&gt;&gt;btnFindPreviousR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnFindPreviousR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;btnFindPreviousR.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="txtReplace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="txtReplace.Location" type="System.Drawing.Point, System.Drawing">
+    <value>59, 28</value>
+  </data>
+  <data name="txtReplace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>370, 21</value>
+  </data>
+  <data name="txtReplace.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;txtReplace.Name" xml:space="preserve">
+    <value>txtReplace</value>
+  </data>
+  <data name="&gt;&gt;txtReplace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtReplace.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;txtReplace.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="txtFindR.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="txtFindR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>59, 6</value>
+  </data>
+  <data name="txtFindR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>370, 21</value>
+  </data>
+  <data name="txtFindR.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;txtFindR.Name" xml:space="preserve">
+    <value>txtFindR</value>
+  </data>
+  <data name="&gt;&gt;txtFindR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;txtFindR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;txtFindR.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="cmdExtCharAndRegExReplace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cmdExtCharAndRegExReplace.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="cmdExtCharAndRegExReplace.Location" type="System.Drawing.Point, System.Drawing">
+    <value>453, 27</value>
+  </data>
+  <data name="cmdExtCharAndRegExReplace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="cmdExtCharAndRegExReplace.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="cmdExtCharAndRegExReplace.Text" xml:space="preserve">
+    <value>&gt;</value>
+  </data>
+  <data name="cmdExtCharAndRegExReplace.ToolTip" xml:space="preserve">
+    <value>Show a list of extended characters</value>
+  </data>
+  <data name="&gt;&gt;cmdExtCharAndRegExReplace.Name" xml:space="preserve">
+    <value>cmdExtCharAndRegExReplace</value>
+  </data>
+  <data name="&gt;&gt;cmdExtCharAndRegExReplace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdExtCharAndRegExReplace.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;cmdExtCharAndRegExReplace.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="cmdExtCharAndRegExFindR.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cmdExtCharAndRegExFindR.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="cmdExtCharAndRegExFindR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>453, 5</value>
+  </data>
+  <data name="cmdExtCharAndRegExFindR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="cmdExtCharAndRegExFindR.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="cmdExtCharAndRegExFindR.Text" xml:space="preserve">
+    <value>&gt;</value>
+  </data>
+  <data name="cmdExtCharAndRegExFindR.ToolTip" xml:space="preserve">
+    <value>Show a list of extended characters</value>
+  </data>
+  <data name="&gt;&gt;cmdExtCharAndRegExFindR.Name" xml:space="preserve">
+    <value>cmdExtCharAndRegExFindR</value>
+  </data>
+  <data name="&gt;&gt;cmdExtCharAndRegExFindR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdExtCharAndRegExFindR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;cmdExtCharAndRegExFindR.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="rdoExtendedR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoExtendedR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>102, 71</value>
+  </data>
+  <data name="rdoExtendedR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>139, 17</value>
+  </data>
+  <data name="rdoExtendedR.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="rdoExtendedR.Text" xml:space="preserve">
+    <value>E&amp;xtended (\n, \r, \t, \0)</value>
+  </data>
+  <data name="&gt;&gt;rdoExtendedR.Name" xml:space="preserve">
+    <value>rdoExtendedR</value>
+  </data>
+  <data name="&gt;&gt;rdoExtendedR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoExtendedR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;rdoExtendedR.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="btnReplaceAll.Location" type="System.Drawing.Point, System.Drawing">
+    <value>7, 212</value>
+  </data>
+  <data name="btnReplaceAll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 23</value>
+  </data>
+  <data name="btnReplaceAll.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="btnReplaceAll.Text" xml:space="preserve">
+    <value>Replace &amp;All</value>
+  </data>
+  <data name="&gt;&gt;btnReplaceAll.Name" xml:space="preserve">
+    <value>btnReplaceAll</value>
+  </data>
+  <data name="&gt;&gt;btnReplaceAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnReplaceAll.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;btnReplaceAll.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="lblReplace.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblReplace.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 32</value>
+  </data>
+  <data name="lblReplace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>45, 13</value>
+  </data>
+  <data name="lblReplace.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="lblReplace.Text" xml:space="preserve">
+    <value>&amp;Replace</value>
+  </data>
+  <data name="&gt;&gt;lblReplace.Name" xml:space="preserve">
+    <value>lblReplace</value>
+  </data>
+  <data name="&gt;&gt;lblReplace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblReplace.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;lblReplace.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="chkSearchSelectionR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkSearchSelectionR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>375, 71</value>
+  </data>
+  <data name="chkSearchSelectionR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>105, 17</value>
+  </data>
+  <data name="chkSearchSelectionR.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="chkSearchSelectionR.Text" xml:space="preserve">
+    <value>Search Selection</value>
+  </data>
+  <data name="&gt;&gt;chkSearchSelectionR.Name" xml:space="preserve">
+    <value>chkSearchSelectionR</value>
+  </data>
+  <data name="&gt;&gt;chkSearchSelectionR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkSearchSelectionR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;chkSearchSelectionR.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="chkWrapR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkWrapR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>375, 52</value>
+  </data>
+  <data name="chkWrapR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>52, 17</value>
+  </data>
+  <data name="chkWrapR.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="chkWrapR.Text" xml:space="preserve">
+    <value>&amp;Wrap</value>
+  </data>
+  <data name="&gt;&gt;chkWrapR.Name" xml:space="preserve">
+    <value>chkWrapR</value>
+  </data>
+  <data name="&gt;&gt;chkWrapR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkWrapR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;chkWrapR.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="btnReplacePrevious.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnReplacePrevious.Location" type="System.Drawing.Point, System.Drawing">
+    <value>364, 188</value>
+  </data>
+  <data name="btnReplacePrevious.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 23</value>
+  </data>
+  <data name="btnReplacePrevious.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="btnReplacePrevious.Text" xml:space="preserve">
+    <value>Replace &amp;Previous</value>
+  </data>
+  <data name="&gt;&gt;btnReplacePrevious.Name" xml:space="preserve">
+    <value>btnReplacePrevious</value>
+  </data>
+  <data name="&gt;&gt;btnReplacePrevious.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnReplacePrevious.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;btnReplacePrevious.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="btnReplaceNext.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="btnReplaceNext.Location" type="System.Drawing.Point, System.Drawing">
+    <value>364, 212</value>
+  </data>
+  <data name="btnReplaceNext.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 23</value>
+  </data>
+  <data name="btnReplaceNext.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="btnReplaceNext.Text" xml:space="preserve">
+    <value>Replace &amp;Next</value>
+  </data>
+  <data name="&gt;&gt;btnReplaceNext.Name" xml:space="preserve">
+    <value>btnReplaceNext</value>
+  </data>
+  <data name="&gt;&gt;btnReplaceNext.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnReplaceNext.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;btnReplaceNext.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="grdOptionsR.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="chkWordStartR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkWordStartR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 37</value>
+  </data>
+  <data name="chkWordStartR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>79, 17</value>
+  </data>
+  <data name="chkWordStartR.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="chkWordStartR.Text" xml:space="preserve">
+    <value>W&amp;ord Start</value>
+  </data>
+  <data name="&gt;&gt;chkWordStartR.Name" xml:space="preserve">
+    <value>chkWordStartR</value>
+  </data>
+  <data name="&gt;&gt;chkWordStartR.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;chkWordStartR.Parent" xml:space="preserve">
     <value>pnlStandardOptionsR</value>
   </data>
-  <data name="pnlStandardOptionsR.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;chkWordStartR.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="txtFindR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem30.Name" xml:space="preserve">
-    <value>toolStripMenuItem30</value>
-  </data>
-  <data name="toolStripMenuItem15.Text" xml:space="preserve">
-    <value>\r\n Windows New Line</value>
-  </data>
-  <data name="chkEcmaScriptR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 37</value>
-  </data>
-  <data name="toolStripMenuItem18.Text" xml:space="preserve">
-    <value>+ One or More Repetitions</value>
-  </data>
-  <data name="toolStripMenuItem36.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator4.Name" xml:space="preserve">
-    <value>toolStripSeparator4</value>
-  </data>
-  <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Tahoma, 8.25pt</value>
-  </data>
-  <data name="toolStripMenuItem42.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="cmdExtCharAndRegExFindF.Text" xml:space="preserve">
-    <value>&gt;</value>
-  </data>
-  <data name="&gt;&gt;rdoStandardF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="chkRightToLeftR.AutoSize" type="System.Boolean, mscorlib">
+  <data name="chkWholeWordR.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem15.Name" xml:space="preserve">
-    <value>toolStripMenuItem15</value>
+  <data name="chkWholeWordR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 20</value>
   </data>
-  <data name="&gt;&gt;tabAll.Name" xml:space="preserve">
-    <value>tabAll</value>
+  <data name="chkWholeWordR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>85, 17</value>
   </data>
-  <data name="chkSinglelineR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="toolStripMenuItem39.Text" xml:space="preserve">
-    <value>\0 Null Character</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem17.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdRecentFindF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="&gt;&gt;rdoExtendedF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;rdoRegexR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem53.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="&gt;&gt;chkExplicitCaptureR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;btnFindNextR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripSeparator7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>257, 6</value>
-  </data>
-  <data name="cmdExtCharAndRegExFindR.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem55.Name" xml:space="preserve">
-    <value>toolStripMenuItem55</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem28.Name" xml:space="preserve">
-    <value>toolStripMenuItem28</value>
-  </data>
-  <data name="cmdExtCharAndRegExFindF.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkCompiledR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="toolStripMenuItem44.Text" xml:space="preserve">
-    <value>( ) Numbered Capture</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem29.Name" xml:space="preserve">
-    <value>toolStripMenuItem29</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkExplicitCaptureR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblFindF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="toolStripSeparator6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>257, 6</value>
-  </data>
-  <data name="chkEcmaScriptR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 17</value>
-  </data>
-  <data name="&gt;&gt;cmdRecentFindR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkCultureInvariantF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkWrapR.Name" xml:space="preserve">
-    <value>chkWrapR</value>
-  </data>
-  <data name="&gt;&gt;btnFindNextF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
-  </data>
-  <data name="&gt;&gt;btnReplaceNext.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="toolStripMenuItem8.Text" xml:space="preserve">
-    <value>\0 Null Character</value>
-  </data>
-  <data name="lblFindR.Text" xml:space="preserve">
-    <value>&amp;Find</value>
-  </data>
-  <data name="chkCompiledR.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="btnClear.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="toolStripMenuItem23.Text" xml:space="preserve">
-    <value>^ Beginning of String or Line</value>
-  </data>
-  <data name="&gt;&gt;cmdRecentFindR.ZOrder" xml:space="preserve">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;cmdExtCharAndRegExFindF.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;tabAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="rdoRegexF.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cmdExtCharAndRegExReplace.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkWordStartR.Text" xml:space="preserve">
-    <value>W&amp;ord Start</value>
-  </data>
-  <data name="chkMatchCaseR.Text" xml:space="preserve">
-    <value>Match &amp;Case</value>
-  </data>
-  <data name="&gt;&gt;chkIgnorePatternWhitespaceR.Name" xml:space="preserve">
-    <value>chkIgnorePatternWhitespaceR</value>
-  </data>
-  <data name="&gt;&gt;chkCultureInvariantF.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;cmdRecentFindF.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="mnuRecentFindF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>36, 4</value>
-  </data>
-  <data name="toolStripMenuItem26.Text" xml:space="preserve">
-    <value>\n Line Feed</value>
-  </data>
-  <data name="&gt;&gt;chkRightToLeftR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;mnuExtendedCharFindF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkIgnorePatternWhitespaceF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 17</value>
-  </data>
-  <data name="lblReplace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 32</value>
-  </data>
-  <data name="chkRightToLeftR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;chkWholeWordF.Parent" xml:space="preserve">
-    <value>pnlStandardOptionsF</value>
-  </data>
-  <data name="chkRightToLeftF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkSearchSelectionF.Text" xml:space="preserve">
-    <value>Search Selection</value>
-  </data>
-  <data name="btnFindPreviousR.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="chkCultureInvariantF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 20</value>
-  </data>
-  <data name="statusStrip.TabIndex" type="System.Int32, mscorlib">
+  <data name="chkWholeWordR.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;rdoExtendedR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkWrapR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="chkMarkLine.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 20</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator2.Name" xml:space="preserve">
-    <value>toolStripSeparator2</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem27.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="lblFindR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;mnuRecentReplace.Name" xml:space="preserve">
-    <value>mnuRecentReplace</value>
-  </data>
-  <data name="chkSinglelineF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 37</value>
-  </data>
-  <data name="chkIgnoreCaseR.Text" xml:space="preserve">
-    <value>&amp;Ignore Case</value>
-  </data>
-  <data name="&gt;&gt;chkEcmaScriptR.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="tpgFind.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="btnFindAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>116, 13</value>
+  <data name="chkWholeWordR.Text" xml:space="preserve">
+    <value>Whole Wor&amp;d</value>
   </data>
   <data name="&gt;&gt;chkWholeWordR.Name" xml:space="preserve">
     <value>chkWholeWordR</value>
   </data>
-  <data name="&gt;&gt;toolStripSeparator5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;chkWholeWordR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkWholeWordR.Parent" xml:space="preserve">
+    <value>pnlStandardOptionsR</value>
+  </data>
+  <data name="&gt;&gt;chkWholeWordR.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="chkMatchCaseR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkMatchCaseR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 3</value>
+  </data>
+  <data name="chkMatchCaseR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>82, 17</value>
+  </data>
+  <data name="chkMatchCaseR.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="chkMatchCaseR.Text" xml:space="preserve">
+    <value>Match &amp;Case</value>
+  </data>
+  <data name="&gt;&gt;chkMatchCaseR.Name" xml:space="preserve">
+    <value>chkMatchCaseR</value>
+  </data>
+  <data name="&gt;&gt;chkMatchCaseR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkMatchCaseR.Parent" xml:space="preserve">
+    <value>pnlStandardOptionsR</value>
+  </data>
+  <data name="&gt;&gt;chkMatchCaseR.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="pnlStandardOptionsR.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="pnlStandardOptionsR.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 17</value>
   </data>
-  <data name="pnlRegexpOptionsR.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="pnlStandardOptionsR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>464, 57</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem10.Name" xml:space="preserve">
-    <value>toolStripMenuItem10</value>
-  </data>
-  <data name="toolStripMenuItem14.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 22</value>
-  </data>
-  <data name="pnlRegexpOptionsF.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="chkIgnoreCaseF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem16.Name" xml:space="preserve">
-    <value>toolStripMenuItem16</value>
-  </data>
-  <data name="&gt;&gt;chkEcmaScriptF.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem19.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdRecentFindR.Name" xml:space="preserve">
-    <value>cmdRecentFindR</value>
-  </data>
-  <data name="toolStripMenuItem49.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="&gt;&gt;btnFindAll.Name" xml:space="preserve">
-    <value>btnFindAll</value>
-  </data>
-  <data name="grpOptionsF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="chkWordStartR.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="toolStripMenuItem9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="chkCompiledF.TabIndex" type="System.Int32, mscorlib">
+  <data name="pnlStandardOptionsR.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;cmdExtCharAndRegExReplace.Name" xml:space="preserve">
-    <value>cmdExtCharAndRegExReplace</value>
+  <data name="&gt;&gt;pnlStandardOptionsR.Name" xml:space="preserve">
+    <value>pnlStandardOptionsR</value>
   </data>
-  <data name="&gt;&gt;cmdRecentFindF.Name" xml:space="preserve">
-    <value>cmdRecentFindF</value>
+  <data name="&gt;&gt;pnlStandardOptionsR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="toolStripMenuItem21.Text" xml:space="preserve">
-    <value>(?&lt;Name&gt;) Named Capture</value>
+  <data name="&gt;&gt;pnlStandardOptionsR.Parent" xml:space="preserve">
+    <value>grdOptionsR</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem16.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="txtFindF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;mnuExtendedCharFindR.Name" xml:space="preserve">
-    <value>mnuExtendedCharFindR</value>
-  </data>
-  <data name="chkSearchSelectionR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="mnuExtendedCharReplace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>175, 114</value>
-  </data>
-  <data name="cmdRecentReplace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;btnReplaceAll.Parent" xml:space="preserve">
-    <value>tpgReplace</value>
-  </data>
-  <data name="cmdExtCharAndRegExReplace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;tTabToolStripMenuItem1.Name" xml:space="preserve">
-    <value>tTabToolStripMenuItem1</value>
-  </data>
-  <data name="chkWordStartF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="lblFindF.Text" xml:space="preserve">
-    <value>&amp;Find</value>
-  </data>
-  <data name="chkMarkLine.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;pnlStandardOptionsR.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;btnReplaceNext.ZOrder" xml:space="preserve">
-    <value>12</value>
+  <data name="chkSinglelineR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="chkMultilineR.ToolTip" xml:space="preserve">
-    <value />
+  <data name="chkSinglelineR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>279, 37</value>
   </data>
-  <data name="&gt;&gt;chkRightToLeftF.Name" xml:space="preserve">
-    <value>chkRightToLeftF</value>
+  <data name="chkSinglelineR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>70, 17</value>
   </data>
-  <data name="&gt;&gt;chkMultilineF.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="chkSinglelineR.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
-  <data name="btnReplaceAll.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;lblSearchTypeF.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;lblFindF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="toolStripMenuItem34.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="chkWholeWordF.Text" xml:space="preserve">
-    <value>Whole Wor&amp;d</value>
-  </data>
-  <data name="tpgReplace.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;lblStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="btnFindNextF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="toolStripMenuItem25.Size" type="System.Drawing.Size, System.Drawing">
-    <value>260, 22</value>
-  </data>
-  <data name="&gt;&gt;cmdExtCharAndRegExReplace.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="cmdRecentFindF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>430, 5</value>
-  </data>
-  <data name="lblSearchTypeF.ToolTip" xml:space="preserve">
-    <value />
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem21.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="btnFindNextR.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;nNewLineToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkSinglelineF.Text" xml:space="preserve">
+  <data name="chkSinglelineR.Text" xml:space="preserve">
     <value>Singleline</value>
   </data>
-  <data name="&gt;&gt;toolStripSeparator5.Name" xml:space="preserve">
-    <value>toolStripSeparator5</value>
+  <data name="&gt;&gt;chkSinglelineR.Name" xml:space="preserve">
+    <value>chkSinglelineR</value>
   </data>
-  <data name="&gt;&gt;btnReplacePrevious.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="toolStripMenuItem51.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 22</value>
-  </data>
-  <data name="btnFindNextR.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;toolStripSeparator3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkCultureInvariantF.Type" xml:space="preserve">
+  <data name="&gt;&gt;chkSinglelineR.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;grpFindAll.Parent" xml:space="preserve">
-    <value>tpgFind</value>
+  <data name="&gt;&gt;chkSinglelineR.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsR</value>
+  </data>
+  <data name="&gt;&gt;chkSinglelineR.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="chkRightToLeftR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkRightToLeftR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>279, 20</value>
+  </data>
+  <data name="chkRightToLeftR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 17</value>
+  </data>
+  <data name="chkRightToLeftR.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="chkRightToLeftR.Text" xml:space="preserve">
+    <value>Right To Left</value>
+  </data>
+  <data name="&gt;&gt;chkRightToLeftR.Name" xml:space="preserve">
+    <value>chkRightToLeftR</value>
+  </data>
+  <data name="&gt;&gt;chkRightToLeftR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkRightToLeftR.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsR</value>
+  </data>
+  <data name="&gt;&gt;chkRightToLeftR.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="chkMultilineR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkMultilineR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>279, 3</value>
+  </data>
+  <data name="chkMultilineR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 17</value>
+  </data>
+  <data name="chkMultilineR.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="chkMultilineR.Text" xml:space="preserve">
+    <value>Multiline</value>
+  </data>
+  <data name="&gt;&gt;chkMultilineR.Name" xml:space="preserve">
+    <value>chkMultilineR</value>
+  </data>
+  <data name="&gt;&gt;chkMultilineR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkMultilineR.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsR</value>
+  </data>
+  <data name="&gt;&gt;chkMultilineR.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="chkIgnorePatternWhitespaceR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkIgnorePatternWhitespaceR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>113, 37</value>
+  </data>
+  <data name="chkIgnorePatternWhitespaceR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>156, 17</value>
+  </data>
+  <data name="chkIgnorePatternWhitespaceR.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="chkIgnorePatternWhitespaceR.Text" xml:space="preserve">
+    <value>I&amp;gnore Pattern Whitespace</value>
+  </data>
+  <data name="&gt;&gt;chkIgnorePatternWhitespaceR.Name" xml:space="preserve">
+    <value>chkIgnorePatternWhitespaceR</value>
+  </data>
+  <data name="&gt;&gt;chkIgnorePatternWhitespaceR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkIgnorePatternWhitespaceR.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsR</value>
+  </data>
+  <data name="&gt;&gt;chkIgnorePatternWhitespaceR.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="chkIgnoreCaseR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkIgnoreCaseR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>113, 20</value>
+  </data>
+  <data name="chkIgnoreCaseR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>85, 17</value>
+  </data>
+  <data name="chkIgnoreCaseR.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="chkIgnoreCaseR.Text" xml:space="preserve">
+    <value>&amp;Ignore Case</value>
+  </data>
+  <data name="&gt;&gt;chkIgnoreCaseR.Name" xml:space="preserve">
+    <value>chkIgnoreCaseR</value>
+  </data>
+  <data name="&gt;&gt;chkIgnoreCaseR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkIgnoreCaseR.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsR</value>
+  </data>
+  <data name="&gt;&gt;chkIgnoreCaseR.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="chkExplicitCaptureR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkExplicitCaptureR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>113, 3</value>
+  </data>
+  <data name="chkExplicitCaptureR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>101, 17</value>
+  </data>
+  <data name="chkExplicitCaptureR.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="chkExplicitCaptureR.Text" xml:space="preserve">
+    <value>E&amp;xplicit Capture</value>
+  </data>
+  <data name="&gt;&gt;chkExplicitCaptureR.Name" xml:space="preserve">
+    <value>chkExplicitCaptureR</value>
+  </data>
+  <data name="&gt;&gt;chkExplicitCaptureR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;chkExplicitCaptureR.Parent" xml:space="preserve">
     <value>pnlRegexpOptionsR</value>
   </data>
-  <data name="toolStripSeparator8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>257, 6</value>
+  <data name="&gt;&gt;chkExplicitCaptureR.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
-  <data name="&gt;&gt;mnuExtendedCharReplace.Name" xml:space="preserve">
-    <value>mnuExtendedCharReplace</value>
+  <data name="chkEcmaScriptR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem20.Name" xml:space="preserve">
-    <value>toolStripMenuItem20</value>
+  <data name="chkEcmaScriptR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 37</value>
+  </data>
+  <data name="chkEcmaScriptR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>84, 17</value>
+  </data>
+  <data name="chkEcmaScriptR.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="chkEcmaScriptR.Text" xml:space="preserve">
+    <value>ECMA Script</value>
+  </data>
+  <data name="&gt;&gt;chkEcmaScriptR.Name" xml:space="preserve">
+    <value>chkEcmaScriptR</value>
+  </data>
+  <data name="&gt;&gt;chkEcmaScriptR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkEcmaScriptR.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsR</value>
+  </data>
+  <data name="&gt;&gt;chkEcmaScriptR.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="chkCultureInvariantR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkCultureInvariantR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 20</value>
+  </data>
+  <data name="chkCultureInvariantR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>108, 17</value>
+  </data>
+  <data name="chkCultureInvariantR.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="chkCultureInvariantR.Text" xml:space="preserve">
+    <value>C&amp;ulture Invariant</value>
+  </data>
+  <data name="&gt;&gt;chkCultureInvariantR.Name" xml:space="preserve">
+    <value>chkCultureInvariantR</value>
+  </data>
+  <data name="&gt;&gt;chkCultureInvariantR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkCultureInvariantR.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsR</value>
+  </data>
+  <data name="&gt;&gt;chkCultureInvariantR.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="chkCompiledR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkCompiledR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="chkCompiledR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 17</value>
+  </data>
+  <data name="chkCompiledR.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="chkCompiledR.Text" xml:space="preserve">
+    <value>&amp;Compiled</value>
+  </data>
+  <data name="&gt;&gt;chkCompiledR.Name" xml:space="preserve">
+    <value>chkCompiledR</value>
+  </data>
+  <data name="&gt;&gt;chkCompiledR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkCompiledR.Parent" xml:space="preserve">
+    <value>pnlRegexpOptionsR</value>
+  </data>
+  <data name="&gt;&gt;chkCompiledR.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="pnlRegexpOptionsR.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="pnlRegexpOptionsR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 17</value>
+  </data>
+  <data name="pnlRegexpOptionsR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>464, 57</value>
+  </data>
+  <data name="pnlRegexpOptionsR.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;pnlRegexpOptionsR.Name" xml:space="preserve">
+    <value>pnlRegexpOptionsR</value>
+  </data>
+  <data name="&gt;&gt;pnlRegexpOptionsR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pnlRegexpOptionsR.Parent" xml:space="preserve">
+    <value>grdOptionsR</value>
+  </data>
+  <data name="&gt;&gt;pnlRegexpOptionsR.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="grdOptionsR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 94</value>
+  </data>
+  <data name="grdOptionsR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>470, 77</value>
+  </data>
+  <data name="grdOptionsR.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="grdOptionsR.Text" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="&gt;&gt;grdOptionsR.Name" xml:space="preserve">
+    <value>grdOptionsR</value>
+  </data>
+  <data name="&gt;&gt;grdOptionsR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grdOptionsR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;grdOptionsR.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="lblSearchTypeR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblSearchTypeR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 52</value>
+  </data>
+  <data name="lblSearchTypeR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>67, 13</value>
+  </data>
+  <data name="lblSearchTypeR.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="lblSearchTypeR.Text" xml:space="preserve">
+    <value>Search Type</value>
+  </data>
+  <data name="&gt;&gt;lblSearchTypeR.Name" xml:space="preserve">
+    <value>lblSearchTypeR</value>
+  </data>
+  <data name="&gt;&gt;lblSearchTypeR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblSearchTypeR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;lblSearchTypeR.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="rdoRegexR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoRegexR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>247, 71</value>
+  </data>
+  <data name="rdoRegexR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 17</value>
+  </data>
+  <data name="rdoRegexR.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="rdoRegexR.Text" xml:space="preserve">
+    <value>Regular &amp;Expression</value>
+  </data>
+  <data name="&gt;&gt;rdoRegexR.Name" xml:space="preserve">
+    <value>rdoRegexR</value>
+  </data>
+  <data name="&gt;&gt;rdoRegexR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoRegexR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;rdoRegexR.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="rdoStandardR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="rdoStandardR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>27, 71</value>
+  </data>
+  <data name="rdoStandardR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>69, 17</value>
+  </data>
+  <data name="rdoStandardR.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="rdoStandardR.Text" xml:space="preserve">
+    <value>&amp;Standard</value>
+  </data>
+  <data name="&gt;&gt;rdoStandardR.Name" xml:space="preserve">
+    <value>rdoStandardR</value>
+  </data>
+  <data name="&gt;&gt;rdoStandardR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rdoStandardR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;rdoStandardR.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="lblFindR.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="lblFindR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 10</value>
+  </data>
+  <data name="lblFindR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>27, 13</value>
+  </data>
+  <data name="lblFindR.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="lblFindR.Text" xml:space="preserve">
+    <value>&amp;Find</value>
+  </data>
+  <data name="&gt;&gt;lblFindR.Name" xml:space="preserve">
+    <value>lblFindR</value>
+  </data>
+  <data name="&gt;&gt;lblFindR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;lblFindR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;lblFindR.ZOrder" xml:space="preserve">
+    <value>17</value>
+  </data>
+  <data name="cmdRecentReplace.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cmdRecentReplace.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="cmdRecentReplace.Location" type="System.Drawing.Point, System.Drawing">
+    <value>430, 27</value>
+  </data>
+  <data name="cmdRecentReplace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="cmdRecentReplace.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="cmdRecentReplace.ToolTip" xml:space="preserve">
+    <value>Show a list of recent search strings</value>
+  </data>
+  <data name="&gt;&gt;cmdRecentReplace.Name" xml:space="preserve">
+    <value>cmdRecentReplace</value>
+  </data>
+  <data name="&gt;&gt;cmdRecentReplace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdRecentReplace.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;cmdRecentReplace.ZOrder" xml:space="preserve">
+    <value>18</value>
+  </data>
+  <data name="cmdRecentFindR.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cmdRecentFindR.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="cmdRecentFindR.Location" type="System.Drawing.Point, System.Drawing">
+    <value>430, 5</value>
+  </data>
+  <data name="cmdRecentFindR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>23, 23</value>
+  </data>
+  <data name="cmdRecentFindR.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="cmdRecentFindR.ToolTip" xml:space="preserve">
+    <value>Show a list of recent search strings</value>
+  </data>
+  <data name="&gt;&gt;cmdRecentFindR.Name" xml:space="preserve">
+    <value>cmdRecentFindR</value>
+  </data>
+  <data name="&gt;&gt;cmdRecentFindR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdRecentFindR.Parent" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;cmdRecentFindR.ZOrder" xml:space="preserve">
+    <value>19</value>
+  </data>
+  <data name="tpgReplace.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpgReplace.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpgReplace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>480, 244</value>
+  </data>
+  <data name="tpgReplace.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpgReplace.Text" xml:space="preserve">
+    <value>Replace</value>
+  </data>
+  <data name="&gt;&gt;tpgReplace.Name" xml:space="preserve">
+    <value>tpgReplace</value>
+  </data>
+  <data name="&gt;&gt;tpgReplace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpgReplace.Parent" xml:space="preserve">
+    <value>tabAll</value>
+  </data>
+  <data name="&gt;&gt;tpgReplace.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tabAll.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tabAll.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tabAll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>488, 270</value>
   </data>
   <data name="tabAll.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="rdoExtendedR.ToolTip" xml:space="preserve">
-    <value />
+  <data name="&gt;&gt;tabAll.Name" xml:space="preserve">
+    <value>tabAll</value>
   </data>
-  <data name="chkWholeWordF.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;tabAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabAll.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tabAll.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>114, 56</value>
+  </metadata>
+  <data name="lblStatus.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 17</value>
+  </data>
+  <data name="statusStrip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 270</value>
+  </data>
+  <data name="statusStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>488, 22</value>
+  </data>
+  <data name="statusStrip.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
-  </data>
-  <data name="lblSearchTypeF.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 52</value>
-  </data>
-  <data name="&gt;&gt;chkMultilineF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="statusStrip.Text" xml:space="preserve">
     <value>xxx</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem26.Name" xml:space="preserve">
-    <value>toolStripMenuItem26</value>
+  <data name="&gt;&gt;statusStrip.Name" xml:space="preserve">
+    <value>statusStrip</value>
   </data>
-  <data name="lblReplace.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="&gt;&gt;statusStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.StatusStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="grpOptionsF.Size" type="System.Drawing.Size, System.Drawing">
-    <value>470, 77</value>
+  <data name="&gt;&gt;statusStrip.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
-  <data name="toolStripMenuItem19.Text" xml:space="preserve">
-    <value>? Zero or More Repetitions</value>
+  <data name="&gt;&gt;statusStrip.ZOrder" xml:space="preserve">
+    <value>10</value>
   </data>
-  <data name="&gt;&gt;txtFindF.Parent" xml:space="preserve">
-    <value>tpgFind</value>
+  <metadata name="mnuExtendedCharFindF.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="toolStripMenuItem13.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
   </data>
-  <data name="btnFindAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 23</value>
+  <data name="toolStripMenuItem13.Text" xml:space="preserve">
+    <value>\r\n Windows New Line</value>
   </data>
-  <data name="chkCultureInvariantF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="nNewLineToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
   </data>
-  <data name="toolStripMenuItem46.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="nNewLineToolStripMenuItem.Text" xml:space="preserve">
+    <value>\n Line Feed</value>
+  </data>
+  <data name="rCarriageToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="rCarriageToolStripMenuItem.Text" xml:space="preserve">
+    <value>\r Carriage Return</value>
+  </data>
+  <data name="tTabToolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="tTabToolStripMenuItem1.Text" xml:space="preserve">
+    <value>\t Tab</value>
+  </data>
+  <data name="nullCharactorToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="nullCharactorToolStripMenuItem.Text" xml:space="preserve">
+    <value>\0 Null Character</value>
+  </data>
+  <data name="mnuExtendedCharFindF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>175, 114</value>
+  </data>
+  <data name="&gt;&gt;mnuExtendedCharFindF.Name" xml:space="preserve">
+    <value>mnuExtendedCharFindF</value>
+  </data>
+  <data name="&gt;&gt;mnuExtendedCharFindF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <metadata name="mnuRecentFindF.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>576, 17</value>
+  </metadata>
+  <data name="toolStripSeparator9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 6</value>
+  </data>
+  <data name="clearHistoryToolStripMenuItemFindF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 22</value>
+  </data>
+  <data name="clearHistoryToolStripMenuItemFindF.Text" xml:space="preserve">
+    <value>&amp;Clear History</value>
+  </data>
+  <data name="mnuRecentFindF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 32</value>
+  </data>
+  <data name="&gt;&gt;mnuRecentFindF.Name" xml:space="preserve">
+    <value>mnuRecentFindF</value>
+  </data>
+  <data name="&gt;&gt;mnuRecentFindF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <metadata name="mnuExtendedCharFindR.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>198, 17</value>
+  </metadata>
+  <data name="toolStripMenuItem14.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="toolStripMenuItem14.Text" xml:space="preserve">
+    <value>\r\n Windows New Line</value>
+  </data>
+  <data name="toolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="toolStripMenuItem1.Text" xml:space="preserve">
+    <value>\n Line Feed</value>
+  </data>
+  <data name="toolStripMenuItem2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="toolStripMenuItem2.Text" xml:space="preserve">
+    <value>\r Carriage Return</value>
+  </data>
+  <data name="toolStripMenuItem3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="toolStripMenuItem3.Text" xml:space="preserve">
+    <value>\t Tab</value>
+  </data>
+  <data name="toolStripMenuItem4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="toolStripMenuItem4.Text" xml:space="preserve">
+    <value>\0 Null Character</value>
+  </data>
+  <data name="mnuExtendedCharFindR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>175, 114</value>
+  </data>
+  <data name="&gt;&gt;mnuExtendedCharFindR.Name" xml:space="preserve">
+    <value>mnuExtendedCharFindR</value>
+  </data>
+  <data name="&gt;&gt;mnuExtendedCharFindR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <metadata name="mnuExtendedCharReplace.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>381, 17</value>
+  </metadata>
+  <data name="toolStripMenuItem15.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="toolStripMenuItem15.Text" xml:space="preserve">
+    <value>\r\n Windows New Line</value>
+  </data>
+  <data name="toolStripMenuItem5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="toolStripMenuItem5.Text" xml:space="preserve">
+    <value>\n Line Feed</value>
+  </data>
+  <data name="toolStripMenuItem6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="toolStripMenuItem6.Text" xml:space="preserve">
+    <value>\r Carriage Return</value>
+  </data>
+  <data name="toolStripMenuItem7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="toolStripMenuItem7.Text" xml:space="preserve">
+    <value>\t Tab</value>
+  </data>
+  <data name="toolStripMenuItem8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 22</value>
+  </data>
+  <data name="toolStripMenuItem8.Text" xml:space="preserve">
+    <value>\0 Null Character</value>
+  </data>
+  <data name="mnuExtendedCharReplace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>175, 114</value>
+  </data>
+  <data name="&gt;&gt;mnuExtendedCharReplace.Name" xml:space="preserve">
+    <value>mnuExtendedCharReplace</value>
+  </data>
+  <data name="&gt;&gt;mnuExtendedCharReplace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <metadata name="mnuRecentFindR.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>719, 17</value>
+  </metadata>
+  <data name="toolStripSeparator10.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 6</value>
+  </data>
+  <data name="clearHistoryToolStripMenuItemFindR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 22</value>
+  </data>
+  <data name="clearHistoryToolStripMenuItemFindR.Text" xml:space="preserve">
+    <value>&amp;Clear History</value>
+  </data>
+  <data name="mnuRecentFindR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 32</value>
+  </data>
+  <data name="&gt;&gt;mnuRecentFindR.Name" xml:space="preserve">
+    <value>mnuRecentFindR</value>
+  </data>
+  <data name="&gt;&gt;mnuRecentFindR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <metadata name="mnuRecentReplace.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>863, 17</value>
+  </metadata>
+  <data name="toolStripSeparator11.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 6</value>
+  </data>
+  <data name="clearHistoryToolStripMenuItemReplace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 22</value>
+  </data>
+  <data name="clearHistoryToolStripMenuItemReplace.Text" xml:space="preserve">
+    <value>&amp;Clear History</value>
+  </data>
+  <data name="mnuRecentReplace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 32</value>
+  </data>
+  <data name="&gt;&gt;mnuRecentReplace.Name" xml:space="preserve">
+    <value>mnuRecentReplace</value>
+  </data>
+  <data name="&gt;&gt;mnuRecentReplace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <metadata name="mnuRegExCharFindF.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>223, 56</value>
+  </metadata>
+  <data name="toolStripMenuItem9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem9.Text" xml:space="preserve">
+    <value>. Any Character</value>
+  </data>
+  <data name="toolStripMenuItem10.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem10.Text" xml:space="preserve">
+    <value>\w Alphanumeric (\W Non-Aplhat)</value>
+  </data>
+  <data name="toolStripMenuItem11.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem11.Text" xml:space="preserve">
+    <value>\d Digit (\D Non-Digit)</value>
+  </data>
+  <data name="toolStripMenuItem12.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem12.Text" xml:space="preserve">
+    <value>\s Whitespace (\S Non-Whitespace)</value>
+  </data>
+  <data name="toolStripMenuItem16.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem16.Text" xml:space="preserve">
+    <value>[a-zA-Z] Specified Set ([^a...] Not in Set)</value>
+  </data>
+  <data name="toolStripSeparator4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>257, 6</value>
+  </data>
+  <data name="toolStripMenuItem25.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem25.Text" xml:space="preserve">
+    <value>\r\n Windows New Line</value>
+  </data>
+  <data name="toolStripMenuItem26.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem26.Text" xml:space="preserve">
+    <value>\n Line Feed</value>
+  </data>
+  <data name="toolStripMenuItem27.Size" type="System.Drawing.Size, System.Drawing">
     <value>260, 22</value>
   </data>
   <data name="toolStripMenuItem27.Text" xml:space="preserve">
     <value>\r Carriage Return</value>
   </data>
-  <data name="rdoStandardR.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+  <data name="toolStripMenuItem28.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
   </data>
-  <data name="&gt;&gt;chkWordStartF.Parent" xml:space="preserve">
-    <value>pnlStandardOptionsF</value>
+  <data name="toolStripMenuItem28.Text" xml:space="preserve">
+    <value>\t Tab</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="toolStripMenuItem29.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
   </data>
-  <data name="chkRightToLeftR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>279, 20</value>
+  <data name="toolStripMenuItem29.Text" xml:space="preserve">
+    <value>\0 Null Character</value>
   </data>
-  <data name="&gt;&gt;lblReplace.ZOrder" xml:space="preserve">
-    <value>8</value>
+  <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>257, 6</value>
   </data>
-  <data name="chkWordStartR.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="toolStripMenuItem17.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
   </data>
-  <data name="chkMultilineF.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="toolStripMenuItem17.Text" xml:space="preserve">
+    <value>* Any Number of Repetitions</value>
   </data>
-  <data name="cmdExtCharAndRegExFindF.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="toolStripMenuItem18.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
   </data>
-  <data name="&gt;&gt;cmdExtCharAndRegExFindF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="toolStripMenuItem18.Text" xml:space="preserve">
+    <value>+ One or More Repetitions</value>
+  </data>
+  <data name="toolStripMenuItem19.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem19.Text" xml:space="preserve">
+    <value>? Zero or More Repetitions</value>
+  </data>
+  <data name="toolStripMenuItem22.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem22.Text" xml:space="preserve">
+    <value>? As Few as Possible (i.e. *?, +? or ??)</value>
+  </data>
+  <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>257, 6</value>
+  </data>
+  <data name="toolStripMenuItem20.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem20.Text" xml:space="preserve">
+    <value>( ) Numbered Capture</value>
+  </data>
+  <data name="toolStripMenuItem21.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem21.Text" xml:space="preserve">
+    <value>(?&lt;Name&gt;) Named Capture</value>
+  </data>
+  <data name="toolStripSeparator3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>257, 6</value>
+  </data>
+  <data name="toolStripMenuItem23.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem23.Text" xml:space="preserve">
+    <value>^ Beginning of String or Line</value>
+  </data>
+  <data name="toolStripMenuItem24.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem24.Text" xml:space="preserve">
+    <value>$ End of String or Line</value>
+  </data>
+  <data name="mnuRegExCharFindF.Size" type="System.Drawing.Size, System.Drawing">
+    <value>261, 424</value>
+  </data>
+  <data name="&gt;&gt;mnuRegExCharFindF.Name" xml:space="preserve">
+    <value>mnuRegExCharFindF</value>
+  </data>
+  <data name="&gt;&gt;mnuRegExCharFindF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <metadata name="mnuRegExCharFindR.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>378, 56</value>
   </metadata>
-  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>86</value>
-  </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 56</value>
-  </metadata>
-  <metadata name="mnuRegExCharFindF.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>223, 56</value>
-  </metadata>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="mnuRecentFindR.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>719, 17</value>
-  </metadata>
-  <metadata name="mnuExtendedCharReplace.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>381, 17</value>
-  </metadata>
-  <metadata name="mnuRecentReplace.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>863, 17</value>
-  </metadata>
-  <metadata name="mnuRecentFindF.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>576, 17</value>
-  </metadata>
-  <metadata name="mnuExtendedCharFindF.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>114, 56</value>
-  </metadata>
-  <metadata name="mnuExtendedCharFindR.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>198, 17</value>
-  </metadata>
+  <data name="toolStripMenuItem30.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem30.Text" xml:space="preserve">
+    <value>. Any Character</value>
+  </data>
+  <data name="toolStripMenuItem31.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem31.Text" xml:space="preserve">
+    <value>\w Alphanumeric (\W Non-Aplhat)</value>
+  </data>
+  <data name="toolStripMenuItem32.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem32.Text" xml:space="preserve">
+    <value>\d Digit (\D Non-Digit)</value>
+  </data>
+  <data name="toolStripMenuItem33.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem33.Text" xml:space="preserve">
+    <value>\s Whitespace (\S Non-Whitespace)</value>
+  </data>
+  <data name="toolStripMenuItem34.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem34.Text" xml:space="preserve">
+    <value>[a-zA-Z] Specified Set ([^a...] Not in Set)</value>
+  </data>
+  <data name="toolStripSeparator5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>257, 6</value>
+  </data>
+  <data name="toolStripMenuItem35.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem35.Text" xml:space="preserve">
+    <value>\r\n Windows New Line</value>
+  </data>
+  <data name="toolStripMenuItem36.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem36.Text" xml:space="preserve">
+    <value>\n Line Feed</value>
+  </data>
+  <data name="toolStripMenuItem37.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem37.Text" xml:space="preserve">
+    <value>\r Carriage Return</value>
+  </data>
+  <data name="toolStripMenuItem38.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem38.Text" xml:space="preserve">
+    <value>\t Tab</value>
+  </data>
+  <data name="toolStripMenuItem39.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem39.Text" xml:space="preserve">
+    <value>\0 Null Character</value>
+  </data>
+  <data name="toolStripSeparator6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>257, 6</value>
+  </data>
+  <data name="toolStripMenuItem40.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem40.Text" xml:space="preserve">
+    <value>* Any Number of Repetitions</value>
+  </data>
+  <data name="toolStripMenuItem41.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem41.Text" xml:space="preserve">
+    <value>+ One or More Repetitions</value>
+  </data>
+  <data name="toolStripMenuItem42.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem42.Text" xml:space="preserve">
+    <value>? Zero or More Repetitions</value>
+  </data>
+  <data name="toolStripMenuItem43.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem43.Text" xml:space="preserve">
+    <value>? As Few as Possible (i.e. *?, +? or ??)</value>
+  </data>
+  <data name="toolStripSeparator7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>257, 6</value>
+  </data>
+  <data name="toolStripMenuItem44.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem44.Text" xml:space="preserve">
+    <value>( ) Numbered Capture</value>
+  </data>
+  <data name="toolStripMenuItem45.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem45.Text" xml:space="preserve">
+    <value>(?&lt;Name&gt;) Named Capture</value>
+  </data>
+  <data name="toolStripSeparator8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>257, 6</value>
+  </data>
+  <data name="toolStripMenuItem46.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem46.Text" xml:space="preserve">
+    <value>^ Beginning of String or Line</value>
+  </data>
+  <data name="toolStripMenuItem47.Size" type="System.Drawing.Size, System.Drawing">
+    <value>260, 22</value>
+  </data>
+  <data name="toolStripMenuItem47.Text" xml:space="preserve">
+    <value>$ End of String or Line</value>
+  </data>
+  <data name="mnuRegExCharFindR.Size" type="System.Drawing.Size, System.Drawing">
+    <value>261, 424</value>
+  </data>
+  <data name="&gt;&gt;mnuRegExCharFindR.Name" xml:space="preserve">
+    <value>mnuRegExCharFindR</value>
+  </data>
+  <data name="&gt;&gt;mnuRegExCharFindR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <metadata name="mnuRegExCharReplace.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>533, 56</value>
   </metadata>
+  <data name="toolStripMenuItem48.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 22</value>
+  </data>
+  <data name="toolStripMenuItem48.Text" xml:space="preserve">
+    <value>$&amp;&amp; Entire Match</value>
+  </data>
+  <data name="toolStripMenuItem49.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 22</value>
+  </data>
+  <data name="toolStripMenuItem49.Text" xml:space="preserve">
+    <value>$1 Numbered Group #1</value>
+  </data>
+  <data name="toolStripMenuItem57.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 22</value>
+  </data>
+  <data name="toolStripMenuItem57.Text" xml:space="preserve">
+    <value>$2 Numbered Group #2</value>
+  </data>
+  <data name="toolStripMenuItem56.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 22</value>
+  </data>
+  <data name="toolStripMenuItem56.Text" xml:space="preserve">
+    <value>$3 Numbered Group #3</value>
+  </data>
+  <data name="toolStripMenuItem55.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 22</value>
+  </data>
+  <data name="toolStripMenuItem55.Text" xml:space="preserve">
+    <value>$4 Numbered Group #4</value>
+  </data>
+  <data name="toolStripMenuItem54.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 22</value>
+  </data>
+  <data name="toolStripMenuItem54.Text" xml:space="preserve">
+    <value>$5 Numbered Group #5</value>
+  </data>
+  <data name="toolStripMenuItem53.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 22</value>
+  </data>
+  <data name="toolStripMenuItem53.Text" xml:space="preserve">
+    <value>$6 Numbered Group #6</value>
+  </data>
+  <data name="toolStripMenuItem52.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 22</value>
+  </data>
+  <data name="toolStripMenuItem52.Text" xml:space="preserve">
+    <value>$7 Numbered Group #7</value>
+  </data>
+  <data name="toolStripMenuItem51.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 22</value>
+  </data>
+  <data name="toolStripMenuItem51.Text" xml:space="preserve">
+    <value>$8 Numbered Group #8</value>
+  </data>
+  <data name="toolStripMenuItem50.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 22</value>
+  </data>
+  <data name="toolStripMenuItem50.Text" xml:space="preserve">
+    <value>$9 Numbered Group #9</value>
+  </data>
+  <data name="nameToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>173, 22</value>
+  </data>
+  <data name="nameToolStripMenuItem.Text" xml:space="preserve">
+    <value>$(Name) Named Group</value>
+  </data>
+  <data name="mnuRegExCharReplace.Size" type="System.Drawing.Size, System.Drawing">
+    <value>174, 246</value>
+  </data>
+  <data name="&gt;&gt;mnuRegExCharReplace.Name" xml:space="preserve">
+    <value>mnuRegExCharReplace</value>
+  </data>
+  <data name="&gt;&gt;mnuRegExCharReplace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>86</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>488, 292</value>
+  </data>
+  <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8.25pt</value>
+  </data>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>504, 331</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Find and Replace</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Name" xml:space="preserve">
+    <value>lblStatus</value>
+  </data>
+  <data name="&gt;&gt;lblStatus.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem13.Name" xml:space="preserve">
+    <value>toolStripMenuItem13</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem13.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nNewLineToolStripMenuItem.Name" xml:space="preserve">
+    <value>nNewLineToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;nNewLineToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rCarriageToolStripMenuItem.Name" xml:space="preserve">
+    <value>rCarriageToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;rCarriageToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tTabToolStripMenuItem1.Name" xml:space="preserve">
+    <value>tTabToolStripMenuItem1</value>
+  </data>
+  <data name="&gt;&gt;tTabToolStripMenuItem1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nullCharactorToolStripMenuItem.Name" xml:space="preserve">
+    <value>nullCharactorToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;nullCharactorToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
+    <value>toolTip1</value>
+  </data>
+  <data name="&gt;&gt;toolTip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolTip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem14.Name" xml:space="preserve">
+    <value>toolStripMenuItem14</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem14.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem1.Name" xml:space="preserve">
+    <value>toolStripMenuItem1</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem2.Name" xml:space="preserve">
+    <value>toolStripMenuItem2</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem3.Name" xml:space="preserve">
+    <value>toolStripMenuItem3</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem4.Name" xml:space="preserve">
+    <value>toolStripMenuItem4</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem15.Name" xml:space="preserve">
+    <value>toolStripMenuItem15</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem15.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem5.Name" xml:space="preserve">
+    <value>toolStripMenuItem5</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem6.Name" xml:space="preserve">
+    <value>toolStripMenuItem6</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem7.Name" xml:space="preserve">
+    <value>toolStripMenuItem7</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem7.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem8.Name" xml:space="preserve">
+    <value>toolStripMenuItem8</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem9.Name" xml:space="preserve">
+    <value>toolStripMenuItem9</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem9.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem10.Name" xml:space="preserve">
+    <value>toolStripMenuItem10</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem10.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem11.Name" xml:space="preserve">
+    <value>toolStripMenuItem11</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem11.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem12.Name" xml:space="preserve">
+    <value>toolStripMenuItem12</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem12.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem16.Name" xml:space="preserve">
+    <value>toolStripMenuItem16</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem16.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator4.Name" xml:space="preserve">
+    <value>toolStripSeparator4</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem25.Name" xml:space="preserve">
+    <value>toolStripMenuItem25</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem25.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem26.Name" xml:space="preserve">
+    <value>toolStripMenuItem26</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem26.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem27.Name" xml:space="preserve">
+    <value>toolStripMenuItem27</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem27.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem28.Name" xml:space="preserve">
+    <value>toolStripMenuItem28</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem28.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem29.Name" xml:space="preserve">
+    <value>toolStripMenuItem29</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem29.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator1.Name" xml:space="preserve">
+    <value>toolStripSeparator1</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem17.Name" xml:space="preserve">
+    <value>toolStripMenuItem17</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem17.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem18.Name" xml:space="preserve">
+    <value>toolStripMenuItem18</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem18.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem19.Name" xml:space="preserve">
+    <value>toolStripMenuItem19</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem19.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem22.Name" xml:space="preserve">
+    <value>toolStripMenuItem22</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem22.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator2.Name" xml:space="preserve">
+    <value>toolStripSeparator2</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem20.Name" xml:space="preserve">
+    <value>toolStripMenuItem20</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem20.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem21.Name" xml:space="preserve">
+    <value>toolStripMenuItem21</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem21.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator3.Name" xml:space="preserve">
+    <value>toolStripSeparator3</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem23.Name" xml:space="preserve">
+    <value>toolStripMenuItem23</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem23.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem24.Name" xml:space="preserve">
+    <value>toolStripMenuItem24</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem24.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem30.Name" xml:space="preserve">
+    <value>toolStripMenuItem30</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem30.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem31.Name" xml:space="preserve">
+    <value>toolStripMenuItem31</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem31.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem32.Name" xml:space="preserve">
+    <value>toolStripMenuItem32</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem32.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem33.Name" xml:space="preserve">
+    <value>toolStripMenuItem33</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem33.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem34.Name" xml:space="preserve">
+    <value>toolStripMenuItem34</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem34.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator5.Name" xml:space="preserve">
+    <value>toolStripSeparator5</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem35.Name" xml:space="preserve">
+    <value>toolStripMenuItem35</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem35.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem36.Name" xml:space="preserve">
+    <value>toolStripMenuItem36</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem36.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem37.Name" xml:space="preserve">
+    <value>toolStripMenuItem37</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem37.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem38.Name" xml:space="preserve">
+    <value>toolStripMenuItem38</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem38.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem39.Name" xml:space="preserve">
+    <value>toolStripMenuItem39</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem39.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator6.Name" xml:space="preserve">
+    <value>toolStripSeparator6</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem40.Name" xml:space="preserve">
+    <value>toolStripMenuItem40</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem40.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem41.Name" xml:space="preserve">
+    <value>toolStripMenuItem41</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem41.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem42.Name" xml:space="preserve">
+    <value>toolStripMenuItem42</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem42.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem43.Name" xml:space="preserve">
+    <value>toolStripMenuItem43</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem43.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator7.Name" xml:space="preserve">
+    <value>toolStripSeparator7</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator7.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem44.Name" xml:space="preserve">
+    <value>toolStripMenuItem44</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem44.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem45.Name" xml:space="preserve">
+    <value>toolStripMenuItem45</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem45.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator8.Name" xml:space="preserve">
+    <value>toolStripSeparator8</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem46.Name" xml:space="preserve">
+    <value>toolStripMenuItem46</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem46.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem47.Name" xml:space="preserve">
+    <value>toolStripMenuItem47</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem47.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem48.Name" xml:space="preserve">
+    <value>toolStripMenuItem48</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem48.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem49.Name" xml:space="preserve">
+    <value>toolStripMenuItem49</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem49.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem57.Name" xml:space="preserve">
+    <value>toolStripMenuItem57</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem57.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem56.Name" xml:space="preserve">
+    <value>toolStripMenuItem56</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem56.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem55.Name" xml:space="preserve">
+    <value>toolStripMenuItem55</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem55.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem54.Name" xml:space="preserve">
+    <value>toolStripMenuItem54</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem54.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem53.Name" xml:space="preserve">
+    <value>toolStripMenuItem53</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem53.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem52.Name" xml:space="preserve">
+    <value>toolStripMenuItem52</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem52.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem51.Name" xml:space="preserve">
+    <value>toolStripMenuItem51</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem51.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem50.Name" xml:space="preserve">
+    <value>toolStripMenuItem50</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem50.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;nameToolStripMenuItem.Name" xml:space="preserve">
+    <value>nameToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;nameToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator9.Name" xml:space="preserve">
+    <value>toolStripSeparator9</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator9.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;clearHistoryToolStripMenuItemFindF.Name" xml:space="preserve">
+    <value>clearHistoryToolStripMenuItemFindF</value>
+  </data>
+  <data name="&gt;&gt;clearHistoryToolStripMenuItemFindF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator10.Name" xml:space="preserve">
+    <value>toolStripSeparator10</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator10.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;clearHistoryToolStripMenuItemFindR.Name" xml:space="preserve">
+    <value>clearHistoryToolStripMenuItemFindR</value>
+  </data>
+  <data name="&gt;&gt;clearHistoryToolStripMenuItemFindR.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator11.Name" xml:space="preserve">
+    <value>toolStripSeparator11</value>
+  </data>
+  <data name="&gt;&gt;toolStripSeparator11.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;clearHistoryToolStripMenuItemReplace.Name" xml:space="preserve">
+    <value>clearHistoryToolStripMenuItemReplace</value>
+  </data>
+  <data name="&gt;&gt;clearHistoryToolStripMenuItemReplace.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>FindReplaceDialog</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/ScintillaNet_FindReplaceDialog/GoTo/GoToDialog.cs
+++ b/ScintillaNet_FindReplaceDialog/GoTo/GoToDialog.cs
@@ -29,7 +29,7 @@ namespace ScintillaNET_FindReplaceDialog
                 //	Line #s are 0 based but the users don't think that way
                 _gotoLineNumber--;
                 if (_gotoLineNumber < 0 || _gotoLineNumber >= _maximumLineNumber)
-                    err.SetError(txtGotoLine, "Go to line # must be greater than 0 and less than " + (_maximumLineNumber + 1).ToString());
+                    err.SetError(txtGotoLine, string.Format(Properties.Resources.GoTo_Error_MustBeInRange, _maximumLineNumber + 1));
                 else
                 {
                     _scintilla.Lines[_gotoLineNumber].Goto();
@@ -40,7 +40,7 @@ namespace ScintillaNET_FindReplaceDialog
             }
             else
             {
-                err.SetError(txtGotoLine, "Go to line # must be a numeric value");
+                err.SetError(txtGotoLine, Properties.Resources.GoTo_Error_MustBeNumeric);
             }
         }
 

--- a/ScintillaNet_FindReplaceDialog/Properties/Resources.Designer.cs
+++ b/ScintillaNet_FindReplaceDialog/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace ScintillaNET_FindReplaceDialog.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -77,6 +77,105 @@ namespace ScintillaNET_FindReplaceDialog.Properties {
             get {
                 object obj = ResourceManager.GetObject("DeleteHS", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Line {0}: .
+        /// </summary>
+        internal static string FindAllResults_ResultsLinePrefix {
+            get {
+                return ResourceManager.GetString("FindAllResults_ResultsLinePrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error in Regular Expression: .
+        /// </summary>
+        internal static string FindReplace_Status_ErrorInRegex {
+            get {
+                return ResourceManager.GetString("FindReplace_Status_ErrorInRegex", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Match could not be found.
+        /// </summary>
+        internal static string FindReplace_Status_MatchNotFound {
+            get {
+                return ResourceManager.GetString("FindReplace_Status_MatchNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search match wrapped to the beginning of the document.
+        /// </summary>
+        internal static string FindReplace_Status_MatchWrappedBeginningDocument {
+            get {
+                return ResourceManager.GetString("FindReplace_Status_MatchWrappedBeginningDocument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search match wrapped to the beginning of the selection.
+        /// </summary>
+        internal static string FindReplace_Status_MatchWrappedBeginningSelection {
+            get {
+                return ResourceManager.GetString("FindReplace_Status_MatchWrappedBeginningSelection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search match wrapped to the end of the document.
+        /// </summary>
+        internal static string FindReplace_Status_MatchWrappedEndDocument {
+            get {
+                return ResourceManager.GetString("FindReplace_Status_MatchWrappedEndDocument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search match wrapped to the end of the selection.
+        /// </summary>
+        internal static string FindReplace_Status_MatchWrappedEndSelection {
+            get {
+                return ResourceManager.GetString("FindReplace_Status_MatchWrappedEndSelection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Total found: .
+        /// </summary>
+        internal static string FindReplace_Status_TotalFound {
+            get {
+                return ResourceManager.GetString("FindReplace_Status_TotalFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Total replaced: .
+        /// </summary>
+        internal static string FindReplace_Status_TotalReplaced {
+            get {
+                return ResourceManager.GetString("FindReplace_Status_TotalReplaced", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Go to line # must be greater than 0 and less than {0}.
+        /// </summary>
+        internal static string GoTo_Error_MustBeInRange {
+            get {
+                return ResourceManager.GetString("GoTo_Error_MustBeInRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Go to line # must be a numeric value.
+        /// </summary>
+        internal static string GoTo_Error_MustBeNumeric {
+            get {
+                return ResourceManager.GetString("GoTo_Error_MustBeNumeric", resourceCulture);
             }
         }
         

--- a/ScintillaNet_FindReplaceDialog/Properties/Resources.de.resx
+++ b/ScintillaNet_FindReplaceDialog/Properties/Resources.de.resx
@@ -1,0 +1,156 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="FindAllResults_ResultsLinePrefix" xml:space="preserve">
+    <value>Zeile {0}: </value>
+  </data>
+  <data name="FindReplace_Status_ErrorInRegex" xml:space="preserve">
+    <value>Fehler in Regulärem Ausdruck: </value>
+  </data>
+  <data name="FindReplace_Status_MatchNotFound" xml:space="preserve">
+    <value>Suchbegriff nicht gefunden</value>
+  </data>
+  <data name="FindReplace_Status_MatchWrappedBeginningDocument" xml:space="preserve">
+    <value>Suche wurde am Anfang des Dokuments fortgesetzt</value>
+  </data>
+  <data name="FindReplace_Status_MatchWrappedBeginningSelection" xml:space="preserve">
+    <value>Suche wurde am Anfang der Auswahl fortgesetzt</value>
+  </data>
+  <data name="FindReplace_Status_MatchWrappedEndDocument" xml:space="preserve">
+    <value>Suche wurde am Ende des Dokuments fortgesetzt</value>
+  </data>
+  <data name="FindReplace_Status_MatchWrappedEndSelection" xml:space="preserve">
+    <value>Suche wurde am Ende der Auswahl fortgesetzt</value>
+  </data>
+  <data name="FindReplace_Status_TotalFound" xml:space="preserve">
+    <value>Anzahl gefunden: </value>
+  </data>
+  <data name="FindReplace_Status_TotalReplaced" xml:space="preserve">
+    <value>Anzahl ersetzt: </value>
+  </data>
+  <data name="GoTo_Error_MustBeInRange" xml:space="preserve">
+    <value>Gehe zu Zeile # muss größer als 0 und kleiner als {0} sein</value>
+  </data>
+  <data name="GoTo_Error_MustBeNumeric" xml:space="preserve">
+    <value>Gehe zu Zeile # muss ein numerischer Wert sein</value>
+  </data>
+</root>

--- a/ScintillaNet_FindReplaceDialog/Properties/Resources.resx
+++ b/ScintillaNet_FindReplaceDialog/Properties/Resources.resx
@@ -124,11 +124,44 @@
   <data name="DeleteHS" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\deletehs.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="FindAllResults_ResultsLinePrefix" xml:space="preserve">
+    <value>Line {0}: </value>
+  </data>
+  <data name="FindReplace_Status_ErrorInRegex" xml:space="preserve">
+    <value>Error in Regular Expression: </value>
+  </data>
+  <data name="FindReplace_Status_MatchNotFound" xml:space="preserve">
+    <value>Match could not be found</value>
+  </data>
+  <data name="FindReplace_Status_MatchWrappedBeginningDocument" xml:space="preserve">
+    <value>Search match wrapped to the beginning of the document</value>
+  </data>
+  <data name="FindReplace_Status_MatchWrappedBeginningSelection" xml:space="preserve">
+    <value>Search match wrapped to the beginning of the selection</value>
+  </data>
+  <data name="FindReplace_Status_MatchWrappedEndDocument" xml:space="preserve">
+    <value>Search match wrapped to the end of the document</value>
+  </data>
+  <data name="FindReplace_Status_MatchWrappedEndSelection" xml:space="preserve">
+    <value>Search match wrapped to the end of the selection</value>
+  </data>
+  <data name="FindReplace_Status_TotalFound" xml:space="preserve">
+    <value>Total found: </value>
+  </data>
+  <data name="FindReplace_Status_TotalReplaced" xml:space="preserve">
+    <value>Total replaced: </value>
+  </data>
   <data name="GoToNextMessage" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\gotonextmessage.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="GoToPreviousMessage" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\gotopreviousmessage.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="GoTo_Error_MustBeInRange" xml:space="preserve">
+    <value>Go to line # must be greater than 0 and less than {0}</value>
+  </data>
+  <data name="GoTo_Error_MustBeNumeric" xml:space="preserve">
+    <value>Go to line # must be a numeric value</value>
   </data>
   <data name="LineColorHS" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\resources\linecolorhs.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>

--- a/ScintillaNet_FindReplaceDialog/ScintillaNET_FindReplaceDialog.csproj
+++ b/ScintillaNet_FindReplaceDialog/ScintillaNET_FindReplaceDialog.csproj
@@ -93,6 +93,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <EmbeddedResource Update="Properties\Resources.de.resx" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\Clock.ico" />

--- a/ScintillaNet_FindReplaceDialog/ScintillaNET_FindReplaceDialog.csproj
+++ b/ScintillaNet_FindReplaceDialog/ScintillaNET_FindReplaceDialog.csproj
@@ -63,6 +63,8 @@
     </Compile>
     <Compile Update="Properties\Resources.Designer.cs">
       <DependentUpon>Resources.resx</DependentUpon>
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -86,6 +88,10 @@
     </EmbeddedResource>
     <EmbeddedResource Update="GoTo\GoToDialog.de.resx">
       <DependentUpon>GoToDialog.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This is a follow-up for #3.

 * The "Clear history" menu entries are created in the Designer so that they can be translated normally.
 * All remaining user-visible strings are moved to the generic Resources.resx file (in Properties)

The German translation is also updated accordingly.

(The Demo app is not translated.)