### PR TITLE
make the GoToDialog modal again

### DIFF
--- a/ScintillaNet_FindReplaceDialog/GoTo/GoTo.cs
+++ b/ScintillaNet_FindReplaceDialog/GoTo/GoTo.cs
@@ -40,7 +40,7 @@ namespace ScintillaNET_FindReplaceDialog
 			gd.Scintilla = _scintilla;
 
 			if (!_window.Visible)
-				_window.Show(_scintilla.FindForm());
+				_window.ShowDialog(_scintilla.FindForm());
 
 			//_window.ShowDialog(_scintilla.FindForm());
 			//_window.Show(_scintilla.FindForm());


### PR DESCRIPTION
and therefore display it centered on its parent

Our customer noticed that in the new version, the GoTo dialog was not centered on the main window by default. The easiest way I found to fix this was to make the dialog modal again (as it was before, at least in ScintillaNET 2.6 and what can be seen by the commented-out code).

I am not sure if this is desireable in general. If you don't want to merge this, we can also keep this change in our (private) fork instead.